### PR TITLE
Remove deprecated module args

### DIFF
--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -27,7 +27,6 @@ options:
         description: The host you want to manage.
         required: true
         type: str
-        aliases: [host_name]
     folder:
         description: The folder your host is located in. On create it defaults to C(/).
         type: str
@@ -303,14 +302,6 @@ def run_module():
         name=dict(
             type="str",
             required=True,
-            aliases=["host_name"],
-            deprecated_aliases=[
-                {
-                    "name": "host_name",
-                    "collection_name": "checkmk.general",
-                    "version": "3.0.0",
-                }
-            ],
         ),
         attributes=dict(type="raw", default={}),
         remove_attributes=dict(type="raw", default=[]),

--- a/plugins/modules/host_group.py
+++ b/plugins/modules/host_group.py
@@ -27,7 +27,6 @@ options:
     name:
         description: The name of the host group to be created/modified/deleted.
         type: str
-        aliases: [host_group_name]
     title:
         description: The title (alias) of your host group. If omitted defaults to the name.
         type: str
@@ -37,7 +36,6 @@ options:
               If title is omitted in entry, it defaults to the host group name.
         default: []
         type: raw
-        aliases: [host_groups]
     state:
         description: The state of your host group.
         type: str
@@ -339,28 +337,12 @@ def run_module():
         name=dict(
             type="str",
             required=False,
-            aliases=["host_group_name"],
-            deprecated_aliases=[
-                {
-                    "name": "host_group_name",
-                    "collection_name": "checkmk.general",
-                    "version": "3.0.0",
-                }
-            ],
         ),
         title=dict(type="str", required=False),
         groups=dict(
             type="raw",
             required=False,
             default=[],
-            aliases=["host_groups"],
-            deprecated_aliases=[
-                {
-                    "name": "host_groups",
-                    "collection_name": "checkmk.general",
-                    "version": "3.0.0",
-                }
-            ],
         ),
         state=dict(type="str", default="present", choices=["present", "absent"]),
     )
@@ -403,7 +385,7 @@ def run_module():
         if "title" in module.params and module.params.get("title", ""):
             exit_failed(
                 module,
-                "'title' has only effect when 'name' (deprecated alias 'host_group_name') is defined and not 'groups' (deprecated alias 'host_groups')",
+                "'title' has only effect when 'name' is defined and not 'groups'",
             )
 
         groups = module.params.get("groups")

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -61,12 +61,6 @@ options:
                             - Mutually exclusive with I(rule_id).
                         default: "/"
                         type: str
-            folder:
-                description:
-                  - Folder of the rule.
-                  - Deprecated, use I(location) instead.
-                  - Mutually exclusive with I(location).
-                type: str
             conditions:
                 description: Conditions of the rule.
                 type: dict
@@ -418,7 +412,6 @@ def run_module():
             type="dict",
             required=True,
             options=dict(
-                folder=dict(type="str"),
                 conditions=dict(type="dict"),
                 properties=dict(type="dict"),
                 value_raw=dict(type="str"),
@@ -444,13 +437,6 @@ def run_module():
                     ],
                     mutually_exclusive=[("folder", "rule_id")],
                     apply_defaults=True,
-                    deprecated_aliases=[
-                        {
-                            "name": "folder",
-                            "collection_name": "checkmk.general",
-                            "version": "3.0.0",
-                        }
-                    ],
                 ),
             ),
             mutually_exclusive=[("folder", "location")],

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -439,7 +439,6 @@ def run_module():
                     apply_defaults=True,
                 ),
             ),
-            mutually_exclusive=[("folder", "location")],
         ),
         state=dict(type="str", default="present", choices=["present", "absent"]),
     )


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The following module args have been deprecated for quite some time.
  - host module:
    - `host_name` (use `name` instead)
  - host_group module:
    - `host_group_name` (use `name` instead)
    - `host_groups` (use `groups` instead)
   - rule module:
    - `folder` (use `location` instead)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The deprecated args are removed.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
