### PR TITLE
Service Completition Check in case of redirect

### DIFF
--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -81,11 +81,22 @@ from ansible_collections.tribe29.checkmk.plugins.module_utils.utils import (
 HTTP_CODES = {
     # http_code: (changed, failed, "Message")
     200: (True, False, "Discovery successful."),
+    302: (True, False, "The service discovery background job has been initialized. Redirecting to the 'Wait for service discovery completion' endpoint."),
     400: (False, True, "Bad Request."),
     403: (False, True, "Forbidden: Configuration via WATO is disabled."),
     404: (False, True, "Not Found: Host could not be found."),
     406: (False, True, "Not Acceptable."),
     415: (False, True, "Unsupported Media Type."),
+    500: (False, True, "General Server Error."),
+}
+
+HTTP_CODES_SC = {
+    # http_code: (changed, failed, "Message")
+    200: (True, False, "The service discovery has been completed."),
+    302: (True, False, "The service discovery is still running. Redirecting to the 'Wait for completion' endpoint."),
+    403: (False, True, "Forbidden: Configuration via Setup is disabled."),
+    404: (False, True, "Not Found: There is no running service discovery"),
+    406: (False, True, "Not Acceptable."),
     500: (False, True, "General Server Error."),
 }
 
@@ -123,6 +134,22 @@ class oldDiscoveryAPI(CheckmkAPI):
         )
 
 
+class ServiceCompletionAPI(CheckmkAPI):
+    def get(self):
+        data = {}
+
+        return self._fetch(
+            code_mapping=HTTP_CODES_SC,
+            endpoint=(
+                "objects/service_discovery_run/"
+                + self.params.get("host_name")
+                + "/actions/wait-for-completion/invoke"
+            ),
+            data=data,
+            method="GET",
+        )
+
+
 def run_module():
     module_args = dict(
         server_url=dict(type="str", required=True),
@@ -152,6 +179,11 @@ def run_module():
         discovery = oldDiscoveryAPI(module)
 
     result = discovery.post()
+
+    # If the API returns 302 check if the discovery has completed successfully.
+    while result.http_code == "302":
+        servicecompletion = ServiceCompletionAPI(module)
+        result = servicecompletion.get()
 
     time.sleep(3)
 

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -15,6 +15,67 @@
   run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_hosts }}"
 
+- name: "{{ outer_item.version }} - Update host labels."
+  discovery:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    state: "only_host_labels"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_hosts }}"
+
+- name: "{{ outer_item.version }} - Rescan (Tabula Rasa in 2.1 and before) services."
+  discovery:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    state: "refresh"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_hosts }}"
+
+- name: "{{ outer_item.version }} - Tabula Rasa. (Only 2.2)"
+  discovery:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    state: "refresh"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_hosts }}"
+  when: "'2.2' in outer_item.version"
+
+- name: "{{ outer_item.version }} - Remove vanished services."
+  discovery:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    state: "remove"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_hosts }}"
+
+- name: "{{ outer_item.version }} - Add undecided services to monitoring."
+  discovery:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    state: "new"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_hosts }}"
+
 - name: "{{ outer_item.version }} - Discover hosts."
   discovery:
     server_url: "{{ server_url }}"


### PR DESCRIPTION
Checks now all discovery-options
fixes #322

<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Discovery-module can't handle redirect
- Only "fix_all" option will be tested

Issue Number: #322

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Discovery-module now uses ServiceCompletion-Endpoint to check if service discovery is completed in case of redirect
- Integration test now tests all options of the discovery module

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
fixes #322
Integration tests will run only against 2.0 on github, but were already tested against 2.1 and 2.2 locally.