### PR TITLE
Downtime module - The comment has a default value now

### DIFF
--- a/changelogs/fragments/downtime.yml
+++ b/changelogs/fragments/downtime.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Downtime module - The comment has a default value now: "Created by Ansible"

--- a/changelogs/fragments/downtime.yml
+++ b/changelogs/fragments/downtime.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - Downtime module - The comment has a default value now: "Created by Ansible"
+    - Downtime module - The comment has a default value now

--- a/plugins/modules/downtime.py
+++ b/plugins/modules/downtime.py
@@ -39,6 +39,7 @@ options:
               default 'Set by Ansible' will be used, in combination with state = absent, ALL downtimes of
               a host or host/service will be removed.
         type: str
+        default: Created by Ansible
     duration:
         description:
             - Duration in seconds. When set, the downtime does not begin automatically at a nominated time,

--- a/plugins/modules/downtime.py
+++ b/plugins/modules/downtime.py
@@ -411,7 +411,7 @@ def run_module():
         automation_user=dict(type="str", required=True),
         automation_secret=dict(type="str", required=True, no_log=True),
         host_name=dict(type="str", required=True),
-        comment=dict(type="str"),
+        comment=dict(type="str", default="Created by Ansible"),
         duration=dict(type="int", default=0),
         start_after=dict(type="dict", default={}),
         start_time=dict(type="str", default=""),

--- a/tests/integration/targets/downtime/tasks/test.yml
+++ b/tests/integration/targets/downtime/tasks/test.yml
@@ -37,6 +37,30 @@
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
 
+- name: "{{ outer_item.version }} - Schedule downtime on host without comment."
+  downtime:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    start_time: 2024-03-25T20:39:28Z
+    end_time: 2024-03-26T20:39:28Z
+    state: present
+  loop: "{{ checkmk_hosts }}"
+
+- name: "{{ outer_item.version }} - Delete downtime on host without comment."
+  downtime:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    host_name: "{{ item.name }}"
+    start_time: 2024-03-25T20:39:28Z
+    end_time: 2024-03-26T20:39:28Z
+    state: absent
+  loop: "{{ checkmk_hosts }}"
+
 - name: "{{ outer_item.version }} - Schedule downtime on services with relative times."
   downtime:
     server_url: "{{ server_url }}"


### PR DESCRIPTION
Downtime module: The comment has a default value now: "Created by Ansible"

<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #350 <!-- Delete this, if it does not apply. -->
When calling a downtime task without providing a comment, the task failed with an API error.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The comment field has a default value now
- It still makes sense to provide your own comment with a useful content, though.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
- It still makes sense to provide your own comment with a useful content, though.