### PR TITLE
Fix integration tests for enterprise editions

### DIFF
--- a/plugins/modules/activation.py
+++ b/plugins/modules/activation.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- encoding: utf-8; py-indent-offset: 4 -*-
 
+# Dummy Change to test integration tests
+
 # Copyright: (c) 2022, Robin Gierse <robin.gierse@checkmk.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import absolute_import, division, print_function

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/activation/tasks/prep.yml
+++ b/tests/integration/targets/activation/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/bakery/tasks/main.yml
+++ b/tests/integration/targets/bakery/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/bakery/tasks/prep.yml
+++ b/tests/integration/targets/bakery/tasks/prep.yml
@@ -7,24 +7,28 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Inject a Key into the Sites."  # This is a hack and should never be done in production!
   ansible.builtin.copy:
@@ -34,3 +38,4 @@
     group: "{{ item.site }}"
     mode: "0660"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/contact_group/tasks/main.yml
+++ b/tests/integration/targets/contact_group/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/contact_group/tasks/prep.yml
+++ b/tests/integration/targets/contact_group/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/discovery/tasks/main.yml
+++ b/tests/integration/targets/discovery/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/discovery/tasks/prep.yml
+++ b/tests/integration/targets/discovery/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/downtime/tasks/main.yml
+++ b/tests/integration/targets/downtime/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/downtime/tasks/prep.yml
+++ b/tests/integration/targets/downtime/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/folder/tasks/main.yml
+++ b/tests/integration/targets/folder/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/folder/tasks/prep.yml
+++ b/tests/integration/targets/folder/tasks/prep.yml
@@ -7,25 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
-  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
-  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
-  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
-  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/folder/tasks/prep.yml
+++ b/tests/integration/targets/folder/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | legth) or item.edition == "cre"

--- a/tests/integration/targets/host/tasks/main.yml
+++ b/tests/integration/targets/host/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/host/tasks/prep.yml
+++ b/tests/integration/targets/host/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/host_group/tasks/main.yml
+++ b/tests/integration/targets/host_group/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/host_group/tasks/prep.yml
+++ b/tests/integration/targets/host_group/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/password/tasks/main.yml
+++ b/tests/integration/targets/password/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/password/tasks/prep.yml
+++ b/tests/integration/targets/password/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/rule/tasks/main.yml
+++ b/tests/integration/targets/rule/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/rule/tasks/prep.yml
+++ b/tests/integration/targets/rule/tasks/prep.yml
@@ -7,24 +7,28 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Gather Date and Time Facts on localhost."
   ansible.builtin.setup:

--- a/tests/integration/targets/service_group/tasks/main.yml
+++ b/tests/integration/targets/service_group/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/service_group/tasks/prep.yml
+++ b/tests/integration/targets/service_group/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/tag_group/tasks/main.yml
+++ b/tests/integration/targets/tag_group/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/tag_group/tasks/prep.yml
+++ b/tests/integration/targets/tag_group/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"

--- a/tests/integration/targets/user/tasks/main.yml
+++ b/tests/integration/targets/user/tasks/main.yml
@@ -5,7 +5,9 @@
 - name: "Wait for site to be ready."
   ansible.builtin.pause:
     seconds: 5
-  when: "'OVERALL 1' in item.stdout_lines"
+  when: |
+    ((download_pass is defined and download_pass | length) or item.item.edition == 'cre')
+    and (item.stdout_lines is defined and 'OVERALL 1' in item.stdout_lines)
   loop: "{{ site_status.results }}"
 
 - name: "Testing."
@@ -13,3 +15,4 @@
   loop: "{{ test_sites }}"
   loop_control:
     loop_var: outer_item
+  when: (download_pass is defined and download_pass | length) or outer_item.edition == "cre"

--- a/tests/integration/targets/user/tasks/prep.yml
+++ b/tests/integration/targets/user/tasks/prep.yml
@@ -7,21 +7,25 @@
     url_username: "{{ download_user | default(omit) }}"
     url_password: "{{ download_pass | default(omit) }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Install Checkmk Versions."
   ansible.builtin.apt:
     deb: /tmp/checkmk-server-{{ item.site }}.deb
     state: present
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Create Sites."
   ansible.builtin.command: "omd -V {{ item.version }}.{{ item.edition }} create --no-tmpfs --admin-password {{ automation_secret }} {{ item.site }}"
   args:
     creates: "/omd/sites/{{ item.site }}"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"
 
 - name: "Start Sites."
   ansible.builtin.shell: "omd status -b {{ item.site }} || omd start {{ item.site }}"
   register: site_status
   changed_when: site_status.rc == "0"
   loop: "{{ test_sites }}"
+  when: (download_pass is defined and download_pass | length) or item.edition == "cre"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When users outside the Checkmk organization create a pull request, the integrations against enterprise editions fail.
The reason is missing access to a GitHub secret, that contains download credentials for the enterprise edition.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
When the download credentials are not available, the integration tests will skip the relevant tests.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
An alternative approach might be to use CCE instead of CEE, as that edition needs no credentials to download. But it would not be the cleanest approach, as there are technical differences.
