### PR TITLE
Add a Lookup Plugin to get the Checkmk Version of a Server

### DIFF
--- a/changelogs/fragments/lookup.yml
+++ b/changelogs/fragments/lookup.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - Version lookup plugin - Add Version lookup plugin.

--- a/playbooks/demo/full.yml
+++ b/playbooks/demo/full.yml
@@ -1,4 +1,6 @@
 ---
+- name: "Lookup."
+  ansible.builtin.import_playbook: lookup.yml
 - name: "Hosts and Folders."
   ansible.builtin.import_playbook: hosts-and-folders.yml
 - name: "Groups."

--- a/playbooks/demo/lookup.yml
+++ b/playbooks/demo/lookup.yml
@@ -1,0 +1,14 @@
+---
+- name: "Showcase Lookup Plugins."
+  hosts: test
+  strategy: linear
+  gather_facts: false
+  vars_files:
+    - ../vars/auth.yml      # This vars file provides details about your site
+  tasks:
+
+    - name: "Get CMK version."
+      debug:
+        msg: "Version is {{ lookup('checkmk.general.version', server_url+'/'+site, validate_certs=False, automation_user=automation_user, automation_secret=automation_secret)}}" 
+      delegate_to: localhost
+      run_once: 'true'

--- a/playbooks/demo/lookup.yml
+++ b/playbooks/demo/lookup.yml
@@ -7,8 +7,16 @@
     - ../vars/auth.yml      # This vars file provides details about your site
   tasks:
 
-    - name: "Get CMK version."
+    - name: "Get Checkmk version."
       debug:
-        msg: "Version is {{ lookup('checkmk.general.version', server_url+'/'+site, validate_certs=False, automation_user=automation_user, automation_secret=automation_secret)}}" 
+        msg: "Version is {{ version }}"
+      vars:
+        version: "{{ lookup('checkmk.general.version',
+                       server_url + '/' + site,
+                       validate_certs=False,
+                       automation_user=automation_user,
+                       automation_secret=automation_secret
+                   )}}"
+
       delegate_to: localhost
       run_once: 'true'

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -9,9 +9,9 @@ DOCUMENTATION = """
     name: version
     author: Lars Getwan (@lgetwan)
     version_added: "3.1.0"
-    short_description: Get the version of a CMK server
+    short_description: Get the version of a Checkmk server
     description:
-      - Returns the version of a CMK server as a string, e.g. '2.1.0p31.cre'
+      - Returns the version of a Checkmk server as a string, e.g. '2.1.0p31.cre'
     options:
       _terms:
         description: site url
@@ -27,23 +27,25 @@ DOCUMENTATION = """
         type: boolean
         required: False
         default: True
-    notes:
-      - Like all lookups, this runs on the Ansible controller and is unaffected by other keywords such as 'become'.
-        If you need to use different permissions, you must change the command or run Ansible as another user.
-      - Alternatively, you can use a shell/command task that runs against localhost and registers the result.
-      - The directory of the play is used as the current working directory.
 """
 
 EXAMPLES = """
-- name: We could read the file directly, but this shows output from command
-  ansible.builtin.debug:
-      msg: "CMK version: {{ lookup('checkmk.general.version', 'https://myserver/mysite', automation_user='automation', automation_secret='$SECRET'}}."
+- name: "Show Checkmk version"
+  debug:
+    msg: "Server version is {{ version }}"
+  vars:
+    version: "{{ lookup('checkmk.general.version',
+                   server_url + '/' + site,
+                   validate_certs=False,
+                   automation_user=automation_user,
+                   automation_secret=automation_secret
+               )}}"
 """
 
 RETURN = """
   _list:
     description:
-      - server CMK version
+      - server Checkmk version
     type: list
     elements: str
 """

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = """
     name: version
     author: Lars Getwan (@lgetwan)
-    version_added: "3.1"
+    version_added: "3.1.0"
     short_description: Get the version of a CMK server
     description:
       - Returns the version of a CMK server as a string, e.g. '2.1.0p31.cre'

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -1,7 +1,7 @@
 # Copyright: (c) 2023, Lars Getwan <lars.getwan@checkmk.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -48,15 +48,15 @@ RETURN = """
 """
 
 import json
-from ansible.errors import AnsibleError
-from ansible.module_utils.common.text.converters import to_text, to_native
-from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
-from ansible.plugins.lookup import LookupBase
 from urllib.error import HTTPError, URLError
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils.urls import ConnectionError, SSLValidationError, open_url
+from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):
-
     def run(self, terms, variables, **kwargs):
 
         self.set_options(var_options=variables, direct=kwargs)
@@ -77,16 +77,30 @@ class LookupModule(LookupBase):
             }
 
             try:
-                response = open_url(url, data=None, headers=headers, method="GET", validate_certs=validate_certs)
+                response = open_url(
+                    url, 
+                    data=None, 
+                    headers=headers, 
+                    method="GET", 
+                    validate_certs=validate_certs,
+                )
 
             except HTTPError as e:
-                raise AnsibleError("Received HTTP error for %s : %s" % (url, to_native(e)))
+                raise AnsibleError(
+                    "Received HTTP error for %s : %s" % (url, to_native(e))
+                )
             except URLError as e:
-                raise AnsibleError("Failed lookup url for %s : %s" % (url, to_native(e)))
+                raise AnsibleError(
+                    "Failed lookup url for %s : %s" % (url, to_native(e))
+                )
             except SSLValidationError as e:
-                raise AnsibleError("Error validating the server's certificate for %s: %s" % (url, to_native(e)))
+                raise AnsibleError(
+                    "Error validating the server's certificate for %s: %s" % (url, to_native(e))
+                )
             except ConnectionError as e:
-                raise AnsibleError("Error connecting to %s: %s" % (url, to_native(e)))
+                raise AnsibleError(
+                    "Error connecting to %s: %s" % (url, to_native(e))
+                )
 
             checkmkinfo = json.loads(to_text(response.read()))
             ret.append(checkmkinfo.get("versions").get("checkmk"))

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -1,6 +1,3 @@
-#!/usr/bin/python
-# -*- encoding: utf-8; py-indent-offset: 4 -*-
-
 # Copyright: (c) 2023, Lars Getwan <lars.getwan@checkmk.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -9,7 +6,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
     name: version
-    author: Lars Getwan <lars.getwan@checkmk.com>
+    author: Lars Getwan (@lgetwan)
     version_added: "3.1"
     short_description: Get the version of a CMK server
     description:
@@ -38,7 +35,8 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - name: We could read the file directly, but this shows output from command
-ansible.builtin.debug: msg="CMK version installed is{{ lookup('checkmk.general.version', 'https://myserver/mysite' }}."
+  ansible.builtin.debug: 
+      msg: "CMK version installed is{{ lookup('checkmk.general.version', 'https://myserver/mysite', automation_user='automation', automation_secret='$SECRET'}}."
 """
 
 RETURN = """

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -35,8 +36,8 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - name: We could read the file directly, but this shows output from command
-  ansible.builtin.debug: 
-      msg: "CMK version installed is{{ lookup('checkmk.general.version', 'https://myserver/mysite', automation_user='automation', automation_secret='$SECRET'}}."
+  ansible.builtin.debug:
+      msg: "CMK version: {{ lookup('checkmk.general.version', 'https://myserver/mysite', automation_user='automation', automation_secret='$SECRET'}}."
 """
 
 RETURN = """
@@ -78,10 +79,10 @@ class LookupModule(LookupBase):
 
             try:
                 response = open_url(
-                    url, 
-                    data=None, 
-                    headers=headers, 
-                    method="GET", 
+                    url,
+                    data=None,
+                    headers=headers,
+                    method="GET",
                     validate_certs=validate_certs,
                 )
 
@@ -95,12 +96,11 @@ class LookupModule(LookupBase):
                 )
             except SSLValidationError as e:
                 raise AnsibleError(
-                    "Error validating the server's certificate for %s: %s" % (url, to_native(e))
+                    "Error validating the server's certificate for %s: %s"
+                    % (url, to_native(e))
                 )
             except ConnectionError as e:
-                raise AnsibleError(
-                    "Error connecting to %s: %s" % (url, to_native(e))
-                )
+                raise AnsibleError("Error connecting to %s: %s" % (url, to_native(e)))
 
             checkmkinfo = json.loads(to_text(response.read()))
             ret.append(checkmkinfo.get("versions").get("checkmk"))

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+
+# Copyright: (c) 2023, Lars Getwan <lars.getwan@checkmk.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: version
+    author: Lars Getwan <lars.getwan@checkmk.com>
+    version_added: "3.1"
+    short_description: Get the version of a CMK server
+    description:
+      - Returns the version of a CMK server as a string, e.g. '2.1.0p31.cre'
+    options:
+      _terms:
+        description: site url
+        required: True
+      automation_user:
+        description: automation user for the REST API access
+        required: True
+      automation_secret:
+        description: automation secret for the REST API access
+        required: True
+      validate_certs:
+        description: Wether or not to validate TLS cerificates
+        type: boolean
+        required: False
+        default: True
+    notes:
+      - Like all lookups, this runs on the Ansible controller and is unaffected by other keywords such as 'become'.
+        If you need to use different permissions, you must change the command or run Ansible as another user.
+      - Alternatively, you can use a shell/command task that runs against localhost and registers the result.
+      - The directory of the play is used as the current working directory.
+"""
+
+EXAMPLES = """
+- name: We could read the file directly, but this shows output from command
+ansible.builtin.debug: msg="CMK version installed is{{ lookup('checkmk.general.version', 'https://myserver/mysite' }}."
+"""
+
+RETURN = """
+  _list:
+    description:
+      - server CMK version
+    type: list
+    elements: str
+"""
+
+import json
+from ansible.errors import AnsibleError
+from ansible.module_utils.common.text.converters import to_text, to_native
+from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
+from ansible.plugins.lookup import LookupBase
+from urllib.error import HTTPError, URLError
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+
+        self.set_options(var_options=variables, direct=kwargs)
+        user = self.get_option("automation_user")
+        secret = self.get_option("automation_secret")
+        validate_certs = self.get_option("validate_certs")
+
+        ret = []
+        for term in terms:
+            base_url = term + "/check_mk/api/1.0"
+            api_endpoint = "/version"
+            url = base_url + api_endpoint
+
+            headers = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": "Bearer %s %s" % (user, secret),
+            }
+
+            try:
+                response = open_url(url, data=None, headers=headers, method="GET", validate_certs=validate_certs)
+
+            except HTTPError as e:
+                raise AnsibleError("Received HTTP error for %s : %s" % (url, to_native(e)))
+            except URLError as e:
+                raise AnsibleError("Failed lookup url for %s : %s" % (url, to_native(e)))
+            except SSLValidationError as e:
+                raise AnsibleError("Error validating the server's certificate for %s: %s" % (url, to_native(e)))
+            except ConnectionError as e:
+                raise AnsibleError("Error connecting to %s: %s" % (url, to_native(e)))
+
+            checkmkinfo = json.loads(to_text(response.read()))
+            ret.append(checkmkinfo.get("versions").get("checkmk"))
+
+        return ret


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->


## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are no lookup plugins at all

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- With the lookup plugin, the user can query the server's version.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
- The full demo playbook now also uses this lookup
