### PR TITLE
Handle 409 response

### DIFF
--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -17,7 +17,7 @@
 
 - name: "Run Single Discoveries."
   block:
-    - name: "{{ outer_item.version }} - Refresh (Tabula Rasa in 2.1 and before, Rescan in 2.2 and newer)."
+    - name: "{{ outer_item.version }} - Rescan services."
       discovery:
         server_url: "{{ server_url }}"
         site: "{{ outer_item.site }}"
@@ -145,7 +145,7 @@
       run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_hosts }}"
 
-    - name: "{{ outer_item.version }} - Bulk: Refresh (Tabula Rasa in 2.1 and before, Rescan in 2.2 and newer)."
+    - name: "{{ outer_item.version }} - Bulk: Rescan services."
       discovery:
         server_url: "{{ server_url }}"
         site: "{{ outer_item.site }}"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In case the API returns
    - 409 "Conflict: A discovery background job is already running" for single mode
    - 409 "Conflict: A bulk discovery job is already active" in bulk mode
the job is failed and ansible stops.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We check for the 409 response and try again every 0.5 seconds until running the discovery is possible again.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
This PR is mainly for a bug where the discovery endpoint doesn't respond with a redirect and the completion endpoint answers with 404 "no running discovery found"

In case of the bulk discovery it would be worth a discussion if waiting as long as it needs is the right option.
Alternatives would be
    - 409 results in a failed task and stops the playbook (current behavior).
    - 409 results not in a failed task, but also there are no changes made. 
