### PR TITLE
Fix agent role for push agents

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -31,6 +31,7 @@ checkmk_agent_folder: "{{ checkmk_folder_path | default('/') }}"
 checkmk_agent_force_foreign_changes: 'false'
 checkmk_agent_host_attributes:
   ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
+checkmk_agent_push: false
 
 
 # If you trust your local hostnames, you could also use the following

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -31,7 +31,7 @@ checkmk_agent_folder: "{{ checkmk_folder_path | default('/') }}"
 checkmk_agent_force_foreign_changes: 'false'
 checkmk_agent_host_attributes:
   ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
-checkmk_agent_mode: pull 
+checkmk_agent_mode: pull
 
 
 # If you trust your local hostnames, you could also use the following

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -31,7 +31,7 @@ checkmk_agent_folder: "{{ checkmk_folder_path | default('/') }}"
 checkmk_agent_force_foreign_changes: 'false'
 checkmk_agent_host_attributes:
   ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
-checkmk_agent_push: false
+checkmk_agent_mode: pull 
 
 
 # If you trust your local hostnames, you could also use the following

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -107,3 +107,4 @@
   ansible.builtin.wait_for:
     port: 6556
     timeout: 60
+  when: not (checkmk_agent_push | default(false)) | bool

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -107,4 +107,4 @@
   ansible.builtin.wait_for:
     port: 6556
     timeout: 60
-  when: checkmk_agent_mode != 'push'
+  when: checkmk_agent_mode == 'pull'

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -107,4 +107,4 @@
   ansible.builtin.wait_for:
     port: 6556
     timeout: 60
-  when: not (checkmk_agent_push | default(false)) | bool
+  when: checkmk_agent_mode != 'push'

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -14,6 +14,11 @@
   tags:
     - include-system-tasks
 
+- name: "{{ ansible_system }}: Initial push of data for push agent"  # noqa no-changed-when
+  become: true
+  ansible.builtin.shell: cmk-agent-ctl push
+  when: (checkmk_agent_push | default(false)) | bool
+
 - name: "Fetch fresh monitoring data from host."
   become: false
   checkmk.general.discovery:

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: "{{ ansible_system }}: Initial push of data for push agent"  # noqa no-changed-when
   become: true
   ansible.builtin.shell: cmk-agent-ctl push
-  when: (checkmk_agent_push | default(false)) | bool
+  when: checkmk_agent_mode == 'push'
 
 - name: "Fetch fresh monitoring data from host."
   become: false

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: "{{ ansible_system }}: Initial push of data for push agent"  # noqa no-changed-when
   become: true
-  ansible.builtin.shell: cmk-agent-ctl push
+  ansible.builtin.command: cmk-agent-ctl push
   when: checkmk_agent_mode == 'push'
 
 - name: "Fetch fresh monitoring data from host."


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type

- [x] Bugfix (kindof)
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
There is an inbound port check to the host which runs no matter whether we use pull or push agents. Also, if you reploy a push agent, initial discovery will fail, since there is no data.

Issue Number: `#437` <!-- Delete this, if it does not apply. -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- There is a new variable `checkmk-agent-push' which defaults to false.
- If set to `true` the port scan is skipped.
- If set to `true` we trigger a initial push using `cmk-agent-ctl push` beforce running discovery.

## Other information
As said in the issue, that's just the approach I took. I'm not saying it is a clean or general approach. It's confusing because it introduces a variable called `checkmk-agent-push` which doesn't actually activate push agents. Therefore it duplicates information that already has to be present as setting on the target folder.
