### PR TITLE
Fetch checkmk agent from delegated node

### DIFF
--- a/roles/agent/tasks/Debian.yml
+++ b/roles/agent/tasks/Debian.yml
@@ -93,6 +93,20 @@
   tags:
     - download-package
 
+- name: "{{ ansible_os_family }} Derivatives: Fetch GENERIC or folder-specific {{ checkmk_agent_edition | upper }} Agent."
+  ansible.builtin.fetch:
+    src: "{{ checkmk_agent_agent.file.cee }}"
+    dest: "{{ checkmk_agent_agent.file.cee }}"
+    flat: true
+    mode: "0644"
+  when: |
+    checkmk_agent_edition | lower != "cre"
+    and not checkmk_agent_host_specific | bool
+    and checkmk_agent_delegate_download != inventory_hostname
+  delegate_to: "{{ checkmk_agent_delegate_download }}"
+  tags:
+    - download-package
+
 - name: "{{ ansible_os_family }} Derivatives: Transfer GENERIC or folder-specific {{ checkmk_agent_edition | upper }} Agent."
   ansible.builtin.copy:
     src: "{{ checkmk_agent_agent.file.cee }}"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently delegation of agent download is broken if `delegate_to` is not the Ansible server.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I have the following setup:
- A: Checkmk server
- B: Host that should be configured
- C: Host running Ansible
- D: Host already configured with Ansible

It's possible to delegate the download of the agent to a different host (D).

The tasks `Download * Agent` download the agent from A to D. The next task `Transfer GENERIC or folder-specific * Agent` copies the agent from C to B, which fails if C and D are different hosts. Therefore I added a fetch task that copies the agent from D to C.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->

In some scenarios it's not (easily) possible to delegate the agent download to the Ansible server.