### PR TITLE
feat: add no log capability for agent and server roles

### DIFF
--- a/changelogs/fragments/no_log.yml
+++ b/changelogs/fragments/no_log.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Agent role - Avoid logging passwords by default for extra security
+  - Server role - Avoid logging passwords by default for extra security

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -153,6 +153,9 @@ Define an IP address which will be added to the host in Checkmk. This is optiona
 
 Define attributes with which the host will be added to Checkmk.
 
+    checkmk_agent_no_log: 'true'
+
+Whether to log sensitive information like passwords, Ansible output will be censored for enhanced security by default. Set to `false` for easier troubleshooting. Be careful when changing this value in production, passwords may be leaked in operating system logs.
 
 ## Tags
 Tasks are tagged with the following tags:

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -31,7 +31,7 @@ checkmk_agent_folder: "{{ checkmk_folder_path | default('/') }}"
 checkmk_agent_force_foreign_changes: 'false'
 checkmk_agent_host_attributes:
   ipaddress: "{{ checkmk_agent_host_ip | default(omit) }}"
-
+checkmk_agent_no_log: 'true'
 
 # If you trust your local hostnames, you could also use the following
 # to use the local hostname instead of the inventory hostname:

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -80,6 +80,7 @@
     cmk-update-agent register -H {{ checkmk_agent_host_name }} \
     -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_protocol }} \
     -U {{ checkmk_agent_user }} -P {{ checkmk_agent_auth }}
+  no_log: "{{ checkmk_agent_no_log | bool }}"
   register: checkmk_agent_update_state
   when: |
     checkmk_agent_edition | lower != "cre"
@@ -94,6 +95,7 @@
     cmk-update-agent register -H {{ checkmk_agent_host_name }} \
     -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_protocol }} \
     -U {{ checkmk_agent_user }} -S {{ checkmk_agent_auth }}
+  no_log: "{{ checkmk_agent_no_log | bool }}"
   register: checkmk_agent_update_state
   when: |
     checkmk_agent_edition | lower != "cre"
@@ -107,6 +109,7 @@
     cmk-agent-ctl register -H {{ checkmk_agent_host_name }} \
     -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} \
     -U {{ checkmk_agent_user }} -P {{ checkmk_agent_auth }} --trust-cert
+  no_log: "{{ checkmk_agent_no_log | bool }}"
   register: checkmk_agent_tls_state
   when: |
     checkmk_agent_controller_binary.stat.exists | bool

--- a/roles/agent/tasks/Win32NT.yml
+++ b/roles/agent/tasks/Win32NT.yml
@@ -49,6 +49,7 @@
     check_mk_agent.exe updater register -H {{ checkmk_agent_host_name }} \
     -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_protocol }} \
     -U {{ checkmk_agent_user }} -P {{ checkmk_agent_auth }}
+  no_log: "{{ checkmk_agent_no_log | bool }}"
   register: checkmk_agent_update_state
   args:
     chdir: "C:\\Program Files (x86)\\checkmk\\service\\"
@@ -64,6 +65,7 @@
     check_mk_agent.exe updater register -H {{ checkmk_agent_host_name }} \
     -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_protocol }} \
     -U {{ checkmk_agent_user }} -S {{ checkmk_agent_auth }}
+  no_log: "{{ checkmk_agent_no_log | bool }}"
   register: checkmk_agent_update_state
   args:
     chdir: "C:\\Program Files (x86)\\checkmk\\service\\"
@@ -82,6 +84,7 @@
     cmk-agent-ctl.exe register -H {{ checkmk_agent_host_name }} \
     -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} \
     -U {{ checkmk_agent_user }} -P {{ checkmk_agent_auth }} --trust-cert
+  no_log: "{{ checkmk_agent_no_log | bool }}"
   register: checkmk_agent_tls_state
   args:
     chdir: "C:\\Program Files (x86)\\checkmk\\service\\"

--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -61,22 +61,12 @@ Uninstall unused Checkmk versions on the server.
 
     checkmk_server_configure_firewall: 'true'
 
-Whether to allow downgrading a sites version. Note this is not a recommended procedure, and will not be supported for enterprise customers.
-
-    checkmk_server_allow_downgrades: 'false'
-
 Automatically open the necessary ports on the Checkmk server for the
 web interface to be accessible.
 
-    checkmk_server_sites:
-      - name: test
-        version: "{{ checkmk_server_version }}"
-        state: started
-        admin_pw: test
+    checkmk_server_allow_downgrades: 'false'
 
-A dictionary of sites, their version, admin password and state.
-If a higher version is specified for an existing site, a config update resolution method must first be given to update it.
-Valid choices include `install`, `keepold` and `abort`.
+Whether to allow downgrading a sites version. Note this is not a recommended procedure, and will not be supported for enterprise customers.
 
     checkmk_server_sites:
       - name: test
@@ -85,11 +75,21 @@ Valid choices include `install`, `keepold` and `abort`.
         state: started
         admin_pw: test
 
-Directory to backup sites to when updating between versions.
+A dictionary of sites, their version, admin password and state.
+If a higher version is specified for an existing site, a config update resolution method must first be given to update it.
+Valid choices include `install`, `keepold` and `abort`.
+
     checkmk_server_backup_dir: /tmp
 
-Whether to back up sites when updating between versions. Only disable this if you plan on taking manual backups
+Directory to backup sites to when updating between versions.
+
     checkmk_server_backup_on_update: 'true'
+
+Whether to back up sites when updating between versions. Only disable this if you plan on taking manual backups
+
+    checkmk_agent_no_log: 'true'
+
+Whether to log sensitive information like passwords, Ansible output will be censored for enhanced security by default. Set to `false` for easier troubleshooting. Be careful when changing this value in production, passwords may be leaked in operating system logs.
 
 ## Tags
 Tasks are tagged with the following tags:

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -48,3 +48,4 @@ checkmk_server_allow_downgrades: 'false'
 checkmk_server_epel_gpg_check: 'true'
 
 checkmk_server_cleanup: 'false'
+checkmk_server_no_log: 'true'

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -7,7 +7,7 @@
   args:
     executable: /bin/bash
     creates: "/omd/sites/{{ item.name }}"
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   when: item.state != "absent"
   register: checkmk_server_sites_created
@@ -21,7 +21,7 @@
     omd version {{ item.name }} | egrep -o '[^ ]+$'
   args:
     executable: /bin/bash
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   changed_when: "checkmk_server_sites_versions.stdout != item.version + '.' + checkmk_server_edition | lower"
   when: item.state != "absent"
@@ -44,7 +44,7 @@
   args:
     executable: /bin/bash
     creates: "/opt/omd/sites/{{ item.name }}/tmp/run/live"
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   when: item.state == "started"
   register: checkmk_server_sites_started
@@ -59,7 +59,7 @@
   args:
     executable: /bin/bash
     removes: "/opt/omd/sites/{{ item.name }}/tmp/run/live"
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   when: (item.state == "absent") or (item.state == "stopped")
   register: checkmk_server_sites_stopped
@@ -74,7 +74,7 @@
   args:
     executable: /bin/bash
     removes: "/omd/sites/{{ item.name }}"
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   when: item.state == "absent"
   register: checkmk_server_sites_removed
@@ -88,7 +88,7 @@
     echo '{{ item.admin_pw }}' | htpasswd -i /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin
   args:
     executable: /bin/bash
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   when: item.admin_pw is defined and (item.state != "absent") and (item.version | regex_replace('p.*', '') is version('2.1', '<'))
   tags:
@@ -103,7 +103,7 @@
     echo '{{ item.admin_pw }}' | htpasswd -i -B -C 12 /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin
   args:
     executable: /bin/bash
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   when: item.admin_pw is defined and (item.state != "absent") and (item.version | regex_replace('p.*', '') is version('2.1', '>='))
   tags:
@@ -117,4 +117,4 @@
   when: checkmk_server_sites_created.changed | bool and not item.item.admin_pw is defined
   changed_when: true
   notify: Warn site admin password
-  no_log: true
+  no_log: "{{ checkmk_server_no_log | bool }}"


### PR DESCRIPTION
## Pull request type
- [X] Feature

## What is the current behavior?

Resolves: #452

## What is the new behavior?

Introduce `checkmk_agent_no_log` variable to better protect the automation password to be logged in system logs.
