### PR TITLE
Added redirect option for activation endpoint

### DIFF
--- a/roles/agent/handlers/main.yml
+++ b/roles/agent/handlers/main.yml
@@ -7,6 +7,7 @@
     automation_user: "{{ checkmk_agent_user }}"
     automation_secret: "{{ checkmk_agent_auth }}"
     force_foreign_changes: "{{ checkmk_agent_force_foreign_changes }}"
+    redirect: 'true'
     validate_certs: "{{ checkmk_agent_server_validate_certs }}"
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   run_once: true  # noqa run-once[task]

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -59,10 +59,6 @@
   block:
     - name: "Trigger activation of changes."
       ansible.builtin.meta: flush_handlers
-    # ToDo: We should get rid of the following, once we can query the running activation process to know when it is fnished.
-    - name: "Give the activation process time to finish."
-      ansible.builtin.pause:
-        seconds: 30
 
 - name: "{{ ansible_system }}: Check for Agent Updater Binary."
   ansible.builtin.stat:

--- a/roles/agent/tasks/Win32NT.yml
+++ b/roles/agent/tasks/Win32NT.yml
@@ -29,10 +29,6 @@
   block:
     - name: "Trigger activation of changes."
       ansible.builtin.meta: flush_handlers
-    # ToDo: We should get rid of the following, once we can query the running activation process to know when it is fnished.
-    - name: "Give the activation process time to finish."
-      ansible.builtin.pause:
-        seconds: 30
 
 - name: "Check for Agent Controller Binary."
   ansible.windows.win_stat:

--- a/tests/integration/targets/activation/tasks/test.yml
+++ b/tests/integration/targets/activation/tasks/test.yml
@@ -96,3 +96,16 @@
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_hosts }}"
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate with explicit site and redirect."
+  activation:
+    server_url: "{{ server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ automation_user }}"
+    automation_secret: "{{ automation_secret }}"
+    redirect: 'true'
+    force_foreign_changes: 'false'
+    sites:
+      - "{{ outer_item.site }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Redirect option is always set to false in the activation endpoint.
- In the agent role we have a fixed wait time of 30sec after activating changes

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- It's now possible to set redirect to true
- In the agent role the activation handler has redirect set to true, so there's no need to wait anymore

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
Even with redirect set to true, there is no need to handle the redirect (like with service discovery endpoint).
This works without further changes.