### PR TITLE
Improve server role speed by skipping tasks

### DIFF
--- a/roles/server/tasks/Debian.yml
+++ b/roles/server/tasks/Debian.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Install Checkmk Server."
+  when: not 'check-mk-' + checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
   become: true
   ansible.builtin.apt:
     deb: "/tmp/{{ checkmk_server_setup_file }}"

--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -77,6 +77,7 @@
     - enable-repos
 
 - name: "Install Checkmk Server."
+  when: not 'check-mk-' + checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
   become: true
   ansible.builtin.yum:
     name: "/tmp/{{ checkmk_server_setup_file }}"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -20,28 +20,24 @@
 - name: "Get installed Packages."
   ansible.builtin.package_facts:
 
-- name: "Ensure Prerequisites are met."
-  when: not 'check-mk-' + checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
-  block:
+- name: "Update APT Cache."
+  become: true
+  ansible.builtin.apt:
+    update_cache: true
+  when: ansible_os_family == "Debian"
 
-    - name: "Update APT Cache."
-      become: true
-      ansible.builtin.apt:
-        update_cache: true
-      when: ansible_os_family == "Debian"
+- name: "Install Checkmk Prerequisites."
+  become: true
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - "{{ checkmk_server_prerequisites }}"
+  tags:
+    - install-package
+    - install-prerequisites
 
-    - name: "Install Checkmk Prerequisites."
-      become: true
-      ansible.builtin.package:
-        name: "{{ item }}"
-        state: present
-      loop:
-        - "{{ checkmk_server_prerequisites }}"
-      tags:
-        - install-package
-        - install-prerequisites
-
-- name: "Perform Downloads."
+- name: "Downloads Management."
   when: not 'check-mk-' + checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
   block:
 

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -17,73 +17,80 @@
     - include-os-family-vars
     - install-package
 
-- name: "Update APT Cache."
-  become: true
-  ansible.builtin.apt:
-    update_cache: true
-  when: ansible_os_family == "Debian"
+- name: "Get installed Packages."
+  ansible.builtin.package_facts:
 
-- name: "Install Checkmk Prerequisites."
-  become: true
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: present
-  loop:
-    - "{{ checkmk_server_prerequisites }}"
-  tags:
-    - install-package
-    - install-prerequisites
-
-- name: "Download Checkmk Server Setup."
-  ansible.builtin.get_url:
-    url: "{{ checkmk_server_download_url }}"
-    dest: "/tmp/{{ checkmk_server_setup_file }}"
-    mode: "0640"
-    url_username: "{{ checkmk_server_download_user | default(omit) }}"
-    url_password: "{{ checkmk_server_download_pass | default(omit) }}"
-  retries: 3
-  tags:
-    - download-package
-
-- name: "Download Checkmk GPG Key."
-  ansible.builtin.get_url:
-    url: "https://download.checkmk.com/checkmk/Check_MK-pubkey.gpg"
-    dest: "/tmp/Check_MK-pubkey.gpg"
-    mode: "0640"
-  when: checkmk_server_verify_setup | bool
-  retries: 3
-  tags:
-    - download-gpg-key
-
-- name: "GPG Verification on Debian Derivatives."
-  when: checkmk_server_verify_setup | bool and ansible_os_family == "Debian"
+- name: "Ensure Prerequisites are met."
+  when: not 'check-mk-' + checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
   block:
-    - name: "Import Checkmk GPG Key."
-      ansible.builtin.command: "gpg --import /tmp/Check_MK-pubkey.gpg"
-      register: checkmk_server_gpg_import
+
+    - name: "Update APT Cache."
+      become: true
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_os_family == "Debian"
+
+    - name: "Install Checkmk Prerequisites."
+      become: true
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - "{{ checkmk_server_prerequisites }}"
+      tags:
+        - install-package
+        - install-prerequisites
+
+- name: "Perform Downloads."
+  when: not 'check-mk-' + checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
+  block:
+
+    - name: "Download Checkmk Server Setup."
+      ansible.builtin.get_url:
+        url: "{{ checkmk_server_download_url }}"
+        dest: "/tmp/{{ checkmk_server_setup_file }}"
+        mode: "0640"
+        url_username: "{{ checkmk_server_download_user | default(omit) }}"
+        url_password: "{{ checkmk_server_download_pass | default(omit) }}"
+      retries: 3
+      tags:
+        - download-package
+
+    - name: "Download Checkmk GPG Key."
+      ansible.builtin.get_url:
+        url: "https://download.checkmk.com/checkmk/Check_MK-pubkey.gpg"
+        dest: "/tmp/Check_MK-pubkey.gpg"
+        mode: "0640"
       when: checkmk_server_verify_setup | bool
-      changed_when: "'imported: 1' in checkmk_server_gpg_import"
+      retries: 3
+      tags:
+        - download-gpg-key
+
+    - name: "GPG Verification on Debian Derivatives."
+      when: checkmk_server_verify_setup | bool and ansible_os_family == "Debian"
+      block:
+        - name: "Import Checkmk GPG Key."
+          ansible.builtin.command: "gpg --import /tmp/Check_MK-pubkey.gpg"
+          register: checkmk_server_gpg_import
+          when: checkmk_server_verify_setup | bool
+          changed_when: "'imported: 1' in checkmk_server_gpg_import"
+          tags:
+            - import-gpg-key
+
+        - name: "Verify Checkmk Setup."
+          ansible.builtin.command: gpg --verify "/tmp/{{ checkmk_server_setup_file }}"
+          register: checkmk_server_verify_state
+          changed_when: false
+          failed_when: "'Bad signature' in checkmk_server_verify_state.stderr"
+
+    - name: "Import Checkmk GPG Key."
+      become: true
+      ansible.builtin.rpm_key:
+        key: "/tmp/Check_MK-pubkey.gpg"
+        state: present
+      when: checkmk_server_verify_setup | bool and ansible_os_family == "RedHat"
       tags:
         - import-gpg-key
-
-    - name: "Verify Checkmk Setup."
-      ansible.builtin.command: gpg --verify "/tmp/{{ checkmk_server_setup_file }}"
-      register: checkmk_server_verify_state
-      changed_when: false
-      failed_when: "'Bad signature' in checkmk_server_verify_state.stderr"
-
-    - name: "Print Verification Output."
-      ansible.builtin.debug:
-        msg: "{{ checkmk_server_verify_state.stderr_lines }}"
-
-- name: "Import Checkmk GPG Key."
-  become: true
-  ansible.builtin.rpm_key:
-    key: "/tmp/Check_MK-pubkey.gpg"
-    state: present
-  when: checkmk_server_verify_setup | bool and ansible_os_family == "RedHat"
-  tags:
-    - import-gpg-key
 
 - name: Include OS Family specific Playbook.
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->
This pull request adds some conditionals to skip tasks that are not necessary. More specifically, it skips downloading and installing server setups, if the desired version and edition is already installed.

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Server setups would be downloaded, even if the desired version and edition are already installed.
Installation is already idempotent, but the download tasks were not aware of the installed Checkmk versions.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The role now checks for installed packages and skips the download, if it is unnecessary.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
