### PR TITLE
Folder module - Fix idempotency when using attributes parameter for c…

### DIFF
--- a/changelogs/fragments/fix_folder_module_idempotency.yml
+++ b/changelogs/fragments/fix_folder_module_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Folder module - Fix idempotency when using "attributes" parameter for creating a folder.

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -407,7 +407,7 @@ class FolderAPI(CheckmkAPI):
 
     def create(self):
         data = self.desired.copy()
-        if data.get("attributes", {}) != {}:
+        if data.get("attributes", {}) == {}:
             data["attributes"] = data.pop("update_attributes", {})
 
         if data.get("remove_attributes"):


### PR DESCRIPTION
Folder module - Fix idempotency

<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using the _attributes_ parameter for creating a folder, a folder without explicit attributes is created.
When using the _update_attributes_ parameter instead, the folder will get the expected attributes.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Both, _attributes_ & _update_attributes_ can be used to create a folder, and both set the attributes correctly.

