### PR TITLE
Removed check of pw_length

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -236,9 +236,6 @@ from ansible_collections.checkmk.general.plugins.module_utils.types import RESUL
 from ansible_collections.checkmk.general.plugins.module_utils.utils import (
     result_as_dict,
 )
-from ansible_collections.checkmk.general.plugins.module_utils.version import (
-    CheckmkVersion,
-)
 
 USER = (
     "username",
@@ -409,19 +406,6 @@ class UserAPI(CheckmkAPI):
                 return True
         return False
 
-    def shortpassword(self, data):
-        ver = self.getversion()
-        if ver >= CheckmkVersion("2.3.0") and "auth_option" in data:
-            if (
-                "password" in data["auth_option"]
-                and len(data["auth_option"]["password"]) < 12
-            ) or (
-                "secret" in data["auth_option"]
-                and len(data["auth_option"]["secret"]) < 10
-            ):
-                return True
-        return False
-
     def get(self):
         result = self._fetch(
             code_mapping=UserHTTPCodes.get,
@@ -442,44 +426,24 @@ class UserAPI(CheckmkAPI):
         # in the Checkmk API...
         data.setdefault("fullname", data["username"])
 
-        if self.shortpassword(data):
-            result = RESULT(
-                http_code=0,
-                msg="Password too short. For 2.3 and higher, please provide at least 12 characters (automation min. 10).",
-                content="",
-                etag="",
-                failed=True,
-                changed=False,
-            )
-        else:
-            result = self._fetch(
-                code_mapping=UserHTTPCodes.create,
-                endpoint=UserEndpoints.create,
-                data=data,
-                method="POST",
-            )
+        result = self._fetch(
+            code_mapping=UserHTTPCodes.create,
+            endpoint=UserEndpoints.create,
+            data=data,
+            method="POST",
+        )
         return result
 
     def edit(self, etag):
         data = self._build_user_data()
         self.headers["if-Match"] = etag
 
-        if self.shortpassword(data):
-            result = RESULT(
-                http_code=0,
-                msg="Password too short. For 2.3 and higher, please provide at least 12 characters (automation min. 10).",
-                content="",
-                etag="",
-                failed=True,
-                changed=False,
-            )
-        else:
-            result = self._fetch(
-                code_mapping=UserHTTPCodes.edit,
-                endpoint=self._build_default_endpoint(),
-                data=data,
-                method="PUT",
-            )
+        result = self._fetch(
+            code_mapping=UserHTTPCodes.edit,
+            endpoint=self._build_default_endpoint(),
+            data=data,
+            method="PUT",
+        )
 
         return result
 

--- a/tests/integration/targets/user/tasks/test.yml
+++ b/tests/integration/targets/user/tasks/test.yml
@@ -203,44 +203,6 @@
   delegate_to: localhost
   run_once: true # noqa run-once[task]
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test create with short pw for 2.3 (should fail)"
-  user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
-    server_url: "{{ checkmk_var_server_url }}"
-    site: "{{ outer_item.site }}"
-    automation_user: "{{ checkmk_var_automation_user }}"
-    automation_secret: "{{ checkmk_var_automation_secret }}"
-    customer: "{{ (customer != None) | ternary(customer, omit) }}"  # See PR #427
-    name: "autotest"
-    fullname: "autotest"
-    auth_type: "automation"
-    password: "2short"
-    roles:
-      - admin
-    state: "present"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
-  when: "'2.3' in outer_item.version"
-  register: checkmk_shortpwcheck_create
-  failed_when: "'Password too short. For 2.3 and higher' not in checkmk_shortpwcheck_create.msg"
-
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test reset with short pw for 2.3 (should fail)"
-  user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
-    server_url: "{{ checkmk_var_server_url }}"
-    site: "{{ outer_item.site }}"
-    automation_user: "{{ checkmk_var_automation_user }}"
-    automation_secret: "{{ checkmk_var_automation_secret }}"
-    customer: "{{ (customer != None) | ternary(customer, omit) }}"  # See PR #427
-    name: "{{ item.name }}"
-    password: "{{ item.password }}"
-    auth_type: "{{ item.auth_type }}"
-    state: "reset_password"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
-  loop: "{{ checkmk_var_users_new_short_pw }}"
-  when: "'2.3' in outer_item.version"
-  register: checkmk_shortpwcheck_edit
-  failed_when: "'Password too short. For 2.3 and higher' not in checkmk_shortpwcheck_edit.msg"
-
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete users."
   user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
     server_url: "{{ checkmk_var_server_url }}"

--- a/tests/integration/targets/user/vars/main.yml
+++ b/tests/integration/targets/user/vars/main.yml
@@ -1,17 +1,20 @@
 ---
 test_sites:
-  - version: "2.2.0p19"
-    edition: "cme"
-    site: "stable_cme"
-  - version: "2.2.0p19"
-    edition: "cre"
-    site: "stable_cre"
+  # - version: "2.2.0p19"
+  #   edition: "cme"
+  #   site: "stable_cme"
+  # - version: "2.2.0p19"
+  #   edition: "cre"
+  #   site: "stable_cre"
+  - version: "2.3.0-2024.02.15"
+    edition: "cee"
+    site: "master"
   - version: "2.2.0p19"
     edition: "cee"
     site: "stable_cee"
-  - version: "2.1.0p38"
-    edition: "cre"
-    site: "old_cre"
+  # - version: "2.1.0p38"
+  #   edition: "cre"
+  #   site: "old_cre"
 
 checkmk_var_contact_groups:
   - team1
@@ -104,11 +107,6 @@ checkmk_var_users_newpw:
   - name: auto1
     password: "abcdefghij"
     auth_type: automation
-
-checkmk_var_users_new_short_pw:
-  - name: user3
-    password: "abcdefg"
-    auth_type: password
 
 checkmk_var_users_edit:
   - name: admin1

--- a/tests/integration/targets/user/vars/main.yml
+++ b/tests/integration/targets/user/vars/main.yml
@@ -1,20 +1,17 @@
 ---
 test_sites:
-  # - version: "2.2.0p19"
-  #   edition: "cme"
-  #   site: "stable_cme"
-  # - version: "2.2.0p19"
-  #   edition: "cre"
-  #   site: "stable_cre"
-  - version: "2.3.0-2024.02.15"
-    edition: "cee"
-    site: "master"
+  - version: "2.2.0p19"
+    edition: "cme"
+    site: "stable_cme"
+  - version: "2.2.0p19"
+    edition: "cre"
+    site: "stable_cre"
   - version: "2.2.0p19"
     edition: "cee"
     site: "stable_cee"
-  # - version: "2.1.0p38"
-  #   edition: "cre"
-  #   site: "old_cre"
+  - version: "2.1.0p38"
+    edition: "cre"
+    site: "old_cre"
 
 checkmk_var_contact_groups:
   - team1


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We've added a check for the pw length in preparation for 2.3.
But the minimum length of the pw is only the default setting and some users might configure it in a way that shorter passwords are allowed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No check in the ansible anymore. If the pw-length is shorter then the setting on the server, user will get the error from the API

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
