### PR TITLE
Change logic in rule.py irt conditions being overwritten

### DIFF
--- a/changelogs/fragments/fix_rule_conditions_missing.yml
+++ b/changelogs/fragments/fix_rule_conditions_missing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - Rule module - Fix empty rule conditions.

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -583,7 +583,7 @@ def run_module():
         if not rule.get("value_raw"):
             exit_failed(module, "Rule value_raw is required")
         # Default to all hosts if conditions arent given
-        if rule.get("conditions"):
+        if not rule.get("conditions"):
             rule["conditions"] = {
                 "host_tags": [],
                 "host_labels": [],


### PR DESCRIPTION
This always filled `rule["conditions"]` with a empty dict, when conditions were defined. (and didn't fill it with an empty dict when there are no conditions).

## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
`rule["conditions"]` gets overwritten with an empty default dict, when the rule definition contains conditions. The logic is wrong.

## What is the new behavior?
Changed to logic so it works as expected.