### PR TITLE
Fix folder title treatment

### DIFF
--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -31,7 +31,7 @@ options:
         required: true
         type: str
     name:
-        description: The name of your folder. If omitted defaults to the folder name.
+        description: The name (title) of your folder. If omitted defaults to the folder-name from path.
         type: str
         aliases: [title]
     attributes:
@@ -220,7 +220,11 @@ class FolderAPI(CheckmkAPI):
         (self.desired["parent"], self.desired["name"]) = self._normalize_path(
             self.params.get("path")
         )
-        self.desired["title"] = self.params.get("title", self.desired["name"])
+
+        if self.params.get("title"):
+            self.desired["title"] = self.params.get("name")
+        else:
+            self.desired["title"] = self.desired.get("name")
 
         for key in FOLDER:
             if self.params.get(key):

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -403,7 +403,7 @@ class FolderAPI(CheckmkAPI):
             content="",
             etag="",
             failed=False,
-            changed=False,
+            changed=True,
         )
 
     def needs_update(self):

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -221,7 +221,7 @@ class FolderAPI(CheckmkAPI):
             self.params.get("path")
         )
 
-        if self.params.get("title"):
+        if self.params.get("name"):
             self.desired["title"] = self.params.get("name")
         else:
             self.desired["title"] = self.desired.get("name")

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -186,7 +186,7 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
-    that: "folder_title['~' + (item.path | regex_replace('/', '~') | split('~') | last)] == item.verify_name"
+    that: "folder_title[item.path] == item.verify_name"
   vars:
     results: "{{ lookup('checkmk.general.folders',
                     '~',
@@ -196,7 +196,7 @@
                     automation_user=checkmk_var_automation_user,
                     automation_secret=checkmk_var_automation_secret)
               }}"
-    folder_title: "{{ dict((results | map(attribute='id')) | zip(results | map(attribute='title'))) }}"
+    folder_title: "{{ dict((results | map(attribute='id') | map('regex_replace', '/', '~')) | zip(results | map(attribute='title'))) }}"
   loop: "{{ checkmk_var_folders_defaults_test }}"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -186,7 +186,7 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
-    that: "results.title == item.verify_name"
+    that: "results.name == item.verify_name"
   vars:
     results: "{{ lookup('checkmk.general.folder',
                     item.path,

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -186,7 +186,7 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
-    that: "folder_title[item.path | regex_replace('/', '~') ] == item.verify_name"
+    that: "folder_title[item.path | regex_replace('~', '/') ] == item.verify_name"
   vars:
     results: "{{ lookup('checkmk.general.folders',
                     '~',
@@ -196,7 +196,7 @@
                     automation_user=checkmk_var_automation_user,
                     automation_secret=checkmk_var_automation_secret)
               }}"
-    folder_title: "{{ dict((results | map(attribute='id') | map('regex_replace', '/', '~')) | zip(results | map(attribute='title'))) }}"
+    folder_title: "{{ dict((results | map(attribute='id') | map('regex_replace', '~', '/')) | zip(results | map(attribute='title'))) }}"
   loop: "{{ checkmk_var_folders_defaults_test }}"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -186,16 +186,17 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
-    that: "results.name == item.verify_name"
+    that: "folder_title[item.path | regex_replace('/', '~')] == item.verify_name"
   vars:
-    results: "{{ lookup('checkmk.general.folder',
-                    item.path,
+    results: "{{ lookup('checkmk.general.folders',
+                    '~',
                     server_url=checkmk_var_server_url,
                     site=outer_item.site,
                     validate_certs=False,
                     automation_user=checkmk_var_automation_user,
                     automation_secret=checkmk_var_automation_secret)
               }}"
+    folder_title: "{{ dict((results | map(attribute='id')) | zip(results | map(attribute='title'))) }}"
   loop: "{{ checkmk_var_folders_defaults_test }}"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -184,6 +184,22 @@
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
 
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Print created folders."
+  ansible.builtin.debug:
+    var: folder_title
+  vars:
+    results: "{{ lookup('checkmk.general.folders',
+                    '~',
+                    server_url=checkmk_var_server_url,
+                    site=outer_item.site,
+                    validate_certs=False,
+                    automation_user=checkmk_var_automation_user,
+                    automation_secret=checkmk_var_automation_secret)
+              }}"
+    folder_title: "{{ dict((results | map(attribute='id') | map('regex_replace', '~', '/')) | zip(results | map(attribute='title'))) }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
     that: "folder_title[item.path | regex_replace('~', '/') ] == item.verify_name"

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -186,7 +186,7 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
-    that: "folder_title[item.path | regex_replace('/', '~')] == item.verify_name"
+    that: "folder_title['~' + (item.path | regex_replace('/', '~') | split('~') | last)] == item.verify_name"
   vars:
     results: "{{ lookup('checkmk.general.folders',
                     '~',

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -213,7 +213,6 @@
   loop: "{{ checkmk_var_folders_defaults_test }}"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
-  loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -158,3 +158,71 @@
       - "{{ outer_item.site }}"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create folders for defaults test."
+  folder:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ checkmk_var_automation_user }}"
+    automation_secret: "{{ checkmk_var_automation_secret }}"
+    path: "{{ item.path }}"
+    name: "{{ item.name | default(omit) }}"
+    state: "present"
+  loop: "{{ checkmk_var_folders_defaults_test }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
+  activation:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ checkmk_var_automation_user }}"
+    automation_secret: "{{ checkmk_var_automation_secret }}"
+    force_foreign_changes: true
+    sites:
+      - "{{ outer_item.site }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
+  ansible.builtin.assert:
+    that: "results.title == item.verify_name"
+  vars:
+    results: "{{ lookup('checkmk.general.folder',
+                    item.path,
+                    server_url=checkmk_var_server_url,
+                    site=outer_item.site,
+                    validate_certs=False,
+                    automation_user=checkmk_var_automation_user,
+                    automation_secret=checkmk_var_automation_secret)
+              }}"
+  loop: "{{ checkmk_var_folders_defaults_test }}"
+  fail_msg: "Creted folders title does not match to the expected one!"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete folders."
+  folder:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ checkmk_var_automation_user }}"
+    automation_secret: "{{ checkmk_var_automation_secret }}"
+    path: "{{ item.path }}"
+    name: "{{ item.name | default(omit) }}"
+    state: "absent"
+  loop: "{{ checkmk_var_folders_defaults_test }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_var_folders }}"
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
+  activation:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ checkmk_var_automation_user }}"
+    automation_secret: "{{ checkmk_var_automation_secret }}"
+    force_foreign_changes: true
+    sites:
+      - "{{ outer_item.site }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -186,7 +186,7 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
-    that: "folder_title[item.path] == item.verify_name"
+    that: "folder_title[item.path | regex_replace('/', '~') ] == item.verify_name"
   vars:
     results: "{{ lookup('checkmk.general.folders',
                     '~',

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -197,7 +197,6 @@
                     automation_secret=checkmk_var_automation_secret)
               }}"
   loop: "{{ checkmk_var_folders_defaults_test }}"
-  fail_msg: "Creted folders title does not match to the expected one!"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
 

--- a/tests/integration/targets/folder/vars/main.yml
+++ b/tests/integration/targets/folder/vars/main.yml
@@ -44,4 +44,3 @@ checkmk_var_folders_defaults_test:
     verify_name: "Bar"
   - path: /foo/bar/tresure
     verify_name: "treasure"
-

--- a/tests/integration/targets/folder/vars/main.yml
+++ b/tests/integration/targets/folder/vars/main.yml
@@ -35,3 +35,13 @@ checkmk_folder_attr_test:
   attributes:
     tag_criticality: "test"
     tag_networking: "dmz"
+
+checkmk_var_folders_defaults_test:
+  - path: /foo
+    verify_name: "foo"
+  - path: /foo/bar
+    name: Bar
+    verify_name: "Bar"
+  - path: /foo/bar/tresure
+    verify_name: "treasure"
+

--- a/tests/integration/targets/folder/vars/main.yml
+++ b/tests/integration/targets/folder/vars/main.yml
@@ -39,8 +39,6 @@ checkmk_folder_attr_test:
 checkmk_var_folders_defaults_test:
   - path: /foo
     verify_name: "foo"
-  - path: /foo/bar
+  - path: /bar
     name: Bar
     verify_name: "Bar"
-  - path: /foo/bar/tresure
-    verify_name: "treasure"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

fixes bug #569 

and also, so far not detected (introduced in 4.3.0 during rewrite), new bug that parameter folder `title` (alias `name`) is "ignored" entirely.

Extend check to test the mentioned behavior.

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

#569 

parameter `name` aliased by `title` is entirely ignored.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

in check mod, the returned change status is set to True if the changes would have taken place in normal mode.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
