### PR TITLE
Fix folder lookup plugin title

### DIFF
--- a/changelogs/fragments/lookup_folder.yml
+++ b/changelogs/fragments/lookup_folder.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Folder lookup module - Return the complete folder information, not only the extensions.

--- a/plugins/lookup/folder.py
+++ b/plugins/lookup/folder.py
@@ -165,6 +165,6 @@ class LookupModule(LookupBase):
                         response.get("msg", ""),
                     )
                 )
-            ret.append(response.get("extensions"))
+            ret.append(response)
 
         return ret

--- a/tests/integration/targets/lookup_folder/tasks/test.yml
+++ b/tests/integration/targets/lookup_folder/tasks/test.yml
@@ -30,9 +30,9 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get attributes of folder."
   ansible.builtin.debug:
-    msg: "Criticality of {{ checkmk_folder.name }} is {{ extensions.attributes.tag_criticality }}"
+    msg: "Criticality of {{ checkmk_folder.name }} is {{ folder.extensions.attributes.tag_criticality }}"
   vars:
-    extensions: "{{ lookup('checkmk.general.folder',
+    folder: "{{ lookup('checkmk.general.folder',
                     checkmk_folder.path,
                     server_url=checkmk_var_server_url,
                     site=outer_item.site,
@@ -45,9 +45,9 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder criticality."
   ansible.builtin.assert:
-    that: "extensions.attributes.tag_criticality == checkmk_folder.criticality"
+    that: "folder.extensions.attributes.tag_criticality == checkmk_folder.criticality"
   vars:
-    extensions: "{{ lookup('checkmk.general.folder',
+    folder: "{{ lookup('checkmk.general.folder',
                     checkmk_folder.path,
                     server_url=checkmk_var_server_url,
                     site=outer_item.site,
@@ -60,9 +60,9 @@
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables outside the module call."
   ansible.builtin.assert:
-    that: "extensions.attributes.tag_criticality == checkmk_folder.criticality"
+    that: "folder.extensions.attributes.tag_criticality == checkmk_folder.criticality"
   vars:
-    extensions: "{{ lookup('checkmk.general.folder', checkmk_folder.path) }}"
+    folder: "{{ lookup('checkmk.general.folder', checkmk_folder.path) }}"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
   when: outer_item.edition == "stable_cee"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #571 
The folder lookup plugin didn't return the folder title, but only the extensions.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Return the complete folder information, not only the extensions.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
People using this lookup plugin have to adjust the usage of the variables in the reply.
### Before:
```
- name: "Get attributes of folder."
  ansible.builtin.debug:
    msg: "Criticality of /tests is {{ folder.attributes.tag_criticality }}"
  vars:
    folder: "{{ lookup('checkmk.general.folder',
                    '/tests',
                    server_url=server_url,
                    site=site,
                    validate_certs=False,
                    automation_user=automation_user,
                    automation_secret=automation_secret)
              }}"
```
### After:
```
- name: "Get attributes of folder."
  ansible.builtin.debug:
    msg: "Criticality of /tests is {{ folder.extensions.attributes.tag_criticality }}"
  vars:
    folder: "{{ lookup('checkmk.general.folder',
                    checkmk_folder.path,
                    '/tests',
                    site=site,
                    validate_certs=False,
                    automation_user=automation_user,
                    automation_secret=automation_secret)
              }}"
```
