### PR TITLE
Fix host being always initially created in main folder.

### DIFF
--- a/changelogs/fragments/fix_host_initial_folder.yml
+++ b/changelogs/fragments/fix_host_initial_folder.yml
@@ -1,2 +1,2 @@
 bugfixes:
- - Rule module - Fix empty rule conditions.
+ - Host module - Fix hosts being always created in the main directory.

--- a/changelogs/fragments/fix_host_initial_folder.yml
+++ b/changelogs/fragments/fix_host_initial_folder.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - Rule module - Fix empty rule conditions.

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -320,12 +320,7 @@ class HostAPI(CheckmkAPI):
         # Get the current host from the API and set some parameters
         self._get_current()
 
-        if self.state == "present":
-            if (
-                self.params.get("folder")
-                and self.current["folder"] != self.params["folder"]
-            ):
-                self.desired["folder"] = self.params["folder"]
+        self.desired["folder"] = self.params["folder"]
 
         if self.params.get("nodes"):
             self.desired["nodes"] = self.params.get("nodes")
@@ -423,7 +418,7 @@ class HostAPI(CheckmkAPI):
         return HostEndpoints.modify_cluster % self.desired["host_name"]
 
     def _detect_changes_folder(self):
-        current_folder = self.current.get("folder")
+        current_folder = self.current.get("folder", "/")
         desired_folder = self.desired.get("folder")
         changes = []
 

--- a/tests/integration/targets/host/tasks/test.yml
+++ b/tests/integration/targets/host/tasks/test.yml
@@ -19,7 +19,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     attributes:
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
@@ -40,6 +40,22 @@
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
 
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host folder."
+  ansible.builtin.assert:
+    that: "(item.folder | default('/')) == extensions.folder"
+  vars:
+    extensions: "{{ lookup('checkmk.general.host',
+                    item.name,
+                    server_url=checkmk_var_server_url,
+                    site=outer_item.site,
+                    validate_certs=False,
+                    automation_user=checkmk_var_automation_user,
+                    automation_secret=checkmk_var_automation_secret)
+              }}"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_hosts }}"
+
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
   host:
     server_url: "{{ checkmk_var_server_url }}"
@@ -47,7 +63,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
@@ -134,7 +150,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
@@ -160,7 +176,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     attributes:
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
@@ -188,7 +204,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     nodes: "{{ item.nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -217,7 +233,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     nodes: "{{ item.nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -234,7 +250,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ first.name }}"
-    folder: "{{ first.folder }}"
+    folder: "{{ first.folder | default(omit) }}"
     nodes: "{{ second.nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -265,7 +281,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ first.name }}"
-    folder: "{{ first.folder }}"
+    folder: "{{ first.folder | default(omit) }}"
     nodes: "{{ second.nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -284,7 +300,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     add_nodes: "{{ item.add_nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -313,7 +329,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     add_nodes: "{{ item.add_nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -342,7 +358,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     remove_nodes: "{{ item.remove_nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -371,7 +387,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     remove_nodes: "{{ item.remove_nodes }}"
     attributes:
       site: "{{ outer_item.site }}"
@@ -401,7 +417,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
@@ -426,7 +442,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
@@ -506,7 +522,7 @@
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
     nodes: "{{ item.nodes }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
@@ -519,7 +535,7 @@
     automation_user: "{{ checkmk_var_automation_user }}"
     automation_secret: "{{ checkmk_var_automation_secret }}"
     name: "{{ item.name }}"
-    folder: "{{ item.folder }}"
+    folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   delegate_to: localhost
   run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/host/vars/main.yml
+++ b/tests/integration/targets/host/vars/main.yml
@@ -24,6 +24,7 @@ checkmk_var_folders:
     name: Digital
 
 checkmk_hosts:
+  - name: test0.tld
   - name: test1.tld
     folder: "/"
   - name: test2.tld
@@ -36,6 +37,10 @@ checkmk_hosts:
     folder: "/foo/bar1"
 
 checkmk_cluster_hosts:
+  - name: cluster_test0.tld
+    nodes:
+      - "test0.tld"
+      - "test4.tld"
   - name: cluster_test1.tld
     folder: "/"
     nodes:

--- a/tests/integration/targets/host/vars/main.yml
+++ b/tests/integration/targets/host/vars/main.yml
@@ -9,9 +9,10 @@ test_sites:
   - version: "2.1.0p41"
     edition: "cre"
     site: "old_cre"
-  - version: "2.0.0p39"
-    edition: "cre"
-    site: "ancient_cre"
+  # Temporarily disable due to #596 until the permanent change to remove it lands.
+  # - version: "2.0.0p39"
+  #   edition: "cre"
+  #   site: "ancient_cre"
 
 checkmk_var_folders:
   - path: /foo


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Hosts are always created in main folder if previous state was `absent`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Hosts are created in the folder that is provided in the parameters

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
