### PR TITLE
Make discovery module 2.3 ready

### DIFF
--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -40,7 +40,7 @@ options:
         description: The action to perform during discovery.
         type: str
         default: new
-        choices: [new, remove, fix_all, refresh, tabula_rasa, only_host_labels]
+        choices: [new, remove, fix_all, refresh, tabula_rasa, only_host_labels, update_service_labels, monitor_undecided_services]
     do_full_scan:
         description: The option whether to perform a full scan or not. (Bulk mode only).
         type: bool
@@ -57,6 +57,7 @@ options:
 author:
     - Robin Gierse (@robin-checkmk)
     - Michael Sekania (@msekania)
+    - Max Sickora (@max-checkmk)
 """
 
 EXAMPLES = r"""
@@ -241,6 +242,49 @@ class BulkDiscoveryAPI(CheckmkAPI):
         )
 
 
+class newBulkDiscoveryAPI(CheckmkAPI):
+    def post(self):
+        options = {
+            "monitor_undecided_services": False,
+            "remove_vanished_services": False,
+            "update_service_labels": False,
+            "update_host_labels": False,
+        }
+
+        if self.params.get("state") in ["new", "fix_all", "monitor_undecided_services"]:
+            options["monitor_undecided_services"] = True
+        if self.params.get("state") in ["remove", "fix_all"]:
+            options["remove_vanished_services"] = True
+        if self.params.get("state") in ["update_service_labels"]:
+            options["update_service_labels"] = True
+        if self.params.get("state") in ["new", "fix_all", "only_host_labels"]:
+            options["update_host_labels"] = True
+
+        if self.params.get("state") == "refresh":
+            data = {
+                "hostnames": self.params.get("hosts", []),
+                "mode": self.params.get("state"),
+                "do_full_scan": self.params.get("do_full_scan", True),
+                "bulk_size": self.params.get("bulk_size", 1),
+                "ignore_errors": self.params.get("ignore_errors", True),
+            }
+        else:
+            data = {
+                "hostnames": self.params.get("hosts", []),
+                "options": options,
+                "do_full_scan": self.params.get("do_full_scan", True),
+                "bulk_size": self.params.get("bulk_size", 1),
+                "ignore_errors": self.params.get("ignore_errors", True),
+            }
+
+        return self._fetch(
+            code_mapping=HTTP_CODES_BULK,
+            endpoint="domain-types/discovery_run/actions/bulk-discovery-start/invoke",
+            data=data,
+            method="POST",
+        )
+
+
 class ServiceCompletionBulkAPI(CheckmkAPI):
     def get(self):
         data = {}
@@ -292,6 +336,8 @@ def run_module():
                 "refresh",
                 "tabula_rasa",
                 "only_host_labels",
+                "update_service_labels",
+                "monitor_undecided_services",
             ],
         ),
         do_full_scan=dict(type="bool", default=True),
@@ -351,15 +397,24 @@ def run_module():
         module.fail_json(**result_as_dict(result))
 
     if not single_mode and module.params.get("state") == "tabula_rasa":
+        module.params["state"] = "refresh"
+
+    if ver < CheckmkVersion("2.3.0") and module.params.get("state") in [
+        "update_service_labels",
+        "monitor_undecided_services",
+    ]:
         result = RESULT(
             http_code=0,
-            msg="State 'tabula_rasa' does not exist in bulk_discovery, please use refresh!",
+            msg="State is not supported before 2.3.0",
             content="",
             etag="",
             failed=True,
             changed=False,
         )
         module.fail_json(**result_as_dict(result))
+
+    if not single_mode and ver >= CheckmkVersion("2.3.0"):
+        discovery = newBulkDiscoveryAPI(module)
 
     result = wait_for_completion(single_mode, servicecompletion)
 

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -414,15 +414,26 @@ def run_module():
             )
             module.fail_json(**result_as_dict(result))
         if single_mode:
-            result = RESULT(
-                http_code=0,
-                msg="State can only be used in bulk mode",
-                content="",
-                etag="",
-                failed=True,
-                changed=False,
-            )
-            module.fail_json(**result_as_dict(result))
+            if module.params.get("state") == "monitor_undecided_services":
+                result = RESULT(
+                    http_code=0,
+                    msg="State can only be used in bulk mode",
+                    content="",
+                    etag="",
+                    failed=True,
+                    changed=False,
+                )
+                module.fail_json(**result_as_dict(result))
+            if module.params.get("state") == "update_service_labels" and ver < CheckmkVersion("2.3.0p3"):
+                result = RESULT(
+                    http_code=0,
+                    msg="State can only be used in bulk mode",
+                    content="",
+                    etag="",
+                    failed=True,
+                    changed=False,
+                )
+                module.fail_json(**result_as_dict(result))
 
     if not single_mode and ver >= CheckmkVersion("2.3.0"):
         discovery = newBulkDiscoveryAPI(module)

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -399,19 +399,30 @@ def run_module():
     if not single_mode and module.params.get("state") == "tabula_rasa":
         module.params["state"] = "refresh"
 
-    if ver < CheckmkVersion("2.3.0") and module.params.get("state") in [
+    if module.params.get("state") in [
         "update_service_labels",
         "monitor_undecided_services",
     ]:
-        result = RESULT(
-            http_code=0,
-            msg="State is not supported before 2.3.0",
-            content="",
-            etag="",
-            failed=True,
-            changed=False,
-        )
-        module.fail_json(**result_as_dict(result))
+        if ver < CheckmkVersion("2.3.0"):
+            result = RESULT(
+                http_code=0,
+                msg="State is not supported before 2.3.0",
+                content="",
+                etag="",
+                failed=True,
+                changed=False,
+            )
+            module.fail_json(**result_as_dict(result))
+        if single_mode:
+            result = RESULT(
+                http_code=0,
+                msg="State can only be used in bulk mode",
+                content="",
+                etag="",
+                failed=True,
+                changed=False,
+            )
+            module.fail_json(**result_as_dict(result))
 
     if not single_mode and ver >= CheckmkVersion("2.3.0"):
         discovery = newBulkDiscoveryAPI(module)

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -424,7 +424,9 @@ def run_module():
                     changed=False,
                 )
                 module.fail_json(**result_as_dict(result))
-            if module.params.get("state") == "update_service_labels" and ver < CheckmkVersion("2.3.0p3"):
+            if module.params.get(
+                "state"
+            ) == "update_service_labels" and ver < CheckmkVersion("2.3.0p3"):
                 result = RESULT(
                     http_code=0,
                     msg="State can only be used in bulk mode",

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -76,7 +76,7 @@
       delegate_to: localhost
       run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_hosts }}"
-      when: "'2.2' in outer_item.version"
+      when: "not '2.1' in outer_item.version"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Discover hosts (fix_all)."
       discovery:
@@ -197,6 +197,43 @@
         automation_secret: "{{ checkmk_var_automation_secret }}"
         hosts: "{{ checkmk_host_names }}"
         state: "fix_all"
+        bulk_size: 5
+      delegate_to: localhost
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
+      activation:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        force_foreign_changes: true
+        sites:
+          - "{{ outer_item.site }}"
+      delegate_to: localhost
+      run_once: true  # noqa run-once[task]
+
+- name: "Run additional Bulk Discoveries in 2.3."
+  when: "'2.3.0' in outer_item.version"
+  block:
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Update service labels. (only 2.3)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        hosts: "{{ checkmk_host_names }}"
+        state: "update_service_labels"
+        bulk_size: 5
+      delegate_to: localhost
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Monitor undecided services. (only 2.3)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        hosts: "{{ checkmk_host_names }}"
+        state: "monitor_undecided_services"
         bulk_size: 5
       delegate_to: localhost
 

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -65,6 +65,66 @@
       run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_hosts }}"
 
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update service labels. (Should fail < 2.3.0)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        host_name: "{{ item.name }}"
+        state: "update_service_labels"
+      delegate_to: localhost
+      run_once: true  # noqa run-once[task]
+      loop: "{{ checkmk_hosts }}"
+      register: updateservicelabels_output
+      failed_when: "'State is not supported before 2.3.0' not in updateservicelabels_output.msg"
+      when: "not '2.3.0' in outer_item.version"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Monitor undecided services. (Should fail < 2.3.0)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        host_name: "{{ item.name }}"
+        state: "monitor_undecided_services"
+      delegate_to: localhost
+      run_once: true  # noqa run-once[task]
+      loop: "{{ checkmk_hosts }}"
+      register: monitorundecidedservices_output
+      failed_when: "'State is not supported before 2.3.0' not in monitorundecidedservices_output.msg"
+      when: "not '2.3.0' in outer_item.version"      
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update service labels. (Should fail in 2.3.0)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        host_name: "{{ item.name }}"
+        state: "update_service_labels"
+      delegate_to: localhost
+      run_once: true  # noqa run-once[task]
+      loop: "{{ checkmk_hosts }}"
+      register: stableupdateservicelabels_output
+      failed_when: "'State can only be used in bulk mode' not in stableupdateservicelabels_output.msg"
+      when: "'2.3.0' in outer_item.version"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Monitor undecided services. (Should fail in 2.3.0)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        host_name: "{{ item.name }}"
+        state: "monitor_undecided_services"
+      delegate_to: localhost
+      run_once: true  # noqa run-once[task]
+      loop: "{{ checkmk_hosts }}"
+      register: stablemonitorundecidedservices_output
+      failed_when: "'State can only be used in bulk mode' not in stablemonitorundecidedservices_output.msg"
+      when: "'2.3.0' in outer_item.version"
+
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Tabula Rasa. (New since 2.2)"
       discovery:
         server_url: "{{ checkmk_var_server_url }}"
@@ -178,6 +238,58 @@
         bulk_size: 5
       delegate_to: localhost
 
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Update service labels. (Should fail < 2.3.0)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        hosts: "{{ checkmk_host_names }}"
+        state: "update_service_labels"
+        bulk_size: 5
+      delegate_to: localhost
+      register: bulkupdateservicelabels_output
+      failed_when: "'State is not supported before 2.3.0' not in bulkupdateservicelabels_output.msg"
+      when: "not '2.3.0' in outer_item.version"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Monitor undecided services. (Should fail < 2.3.0)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        hosts: "{{ checkmk_host_names }}"
+        state: "monitor_undecided_services"
+        bulk_size: 5
+      delegate_to: localhost
+      register: bulkmonitorundecidedservices_output
+      failed_when: "'State is not supported before 2.3.0' not in bulkmonitorundecidedservices_output.msg"
+      when: "not '2.3.0' in outer_item.version"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Update service labels. (only 2.3)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        hosts: "{{ checkmk_host_names }}"
+        state: "update_service_labels"
+        bulk_size: 5
+      delegate_to: localhost
+      when: "'2.3.0' in outer_item.version"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Monitor undecided services. (only 2.3)"
+      discovery:
+        server_url: "{{ checkmk_var_server_url }}"
+        site: "{{ outer_item.site }}"
+        automation_user: "{{ checkmk_var_automation_user }}"
+        automation_secret: "{{ checkmk_var_automation_secret }}"
+        hosts: "{{ checkmk_host_names }}"
+        state: "monitor_undecided_services"
+        bulk_size: 5
+      delegate_to: localhost
+      when: "'2.3.0' in outer_item.version"
+
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Add undecided services to monitoring."
       discovery:
         server_url: "{{ checkmk_var_server_url }}"
@@ -197,43 +309,6 @@
         automation_secret: "{{ checkmk_var_automation_secret }}"
         hosts: "{{ checkmk_host_names }}"
         state: "fix_all"
-        bulk_size: 5
-      delegate_to: localhost
-
-    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
-      activation:
-        server_url: "{{ checkmk_var_server_url }}"
-        site: "{{ outer_item.site }}"
-        automation_user: "{{ checkmk_var_automation_user }}"
-        automation_secret: "{{ checkmk_var_automation_secret }}"
-        force_foreign_changes: true
-        sites:
-          - "{{ outer_item.site }}"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
-
-- name: "Run additional Bulk Discoveries in 2.3."
-  when: "'2.3.0' in outer_item.version"
-  block:
-    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Update service labels. (only 2.3)"
-      discovery:
-        server_url: "{{ checkmk_var_server_url }}"
-        site: "{{ outer_item.site }}"
-        automation_user: "{{ checkmk_var_automation_user }}"
-        automation_secret: "{{ checkmk_var_automation_secret }}"
-        hosts: "{{ checkmk_host_names }}"
-        state: "update_service_labels"
-        bulk_size: 5
-      delegate_to: localhost
-
-    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Monitor undecided services. (only 2.3)"
-      discovery:
-        server_url: "{{ checkmk_var_server_url }}"
-        site: "{{ outer_item.site }}"
-        automation_user: "{{ checkmk_var_automation_user }}"
-        automation_secret: "{{ checkmk_var_automation_secret }}"
-        hosts: "{{ checkmk_host_names }}"
-        state: "monitor_undecided_services"
         bulk_size: 5
       delegate_to: localhost
 


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #587 

- New options for Bulk discovery aren't implemented
- tabula_rasa doesn't work

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Discovery module is now 2.3 ready
- Discovery module has now 2 new options for 2.3 -> update_service_labels and monitor_undecided_services
- It's possible to use tabula_rasa again (does the same as refresh)

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
