### PR TITLE
Fix rule module integration tests.

### DIFF
--- a/tests/integration/targets/rule/vars/main.yml
+++ b/tests/integration/targets/rule/vars/main.yml
@@ -32,23 +32,25 @@ checkmk_var_rules:
       }
       value_raw: "{'magic': 0.8}"
 
-  - name: "CPU - Load."
-    ruleset: "checkgroup_parameters:cpu_load"
-    rule:
-      location:
-        folder: "/"
-        position: "bottom"
-      conditions: {
-        "host_labels": [],
-        "host_tags": [],
-        "service_labels": []
-      }
-      properties: {
-        "comment": "{{ ansible_date_time.iso8601 }} - Ansible managed",
-        "description": "",
-        "disabled": false
-      }
-      value_raw: "{'levels': (1.0, 2.0)}"
+  ## With 2.3.0, the value_raw should contain "levels15", but with previous versions, it's
+  ## only "levels". Let's reactivate this, once 2.2.0 is out of support.
+  # - name: "CPU - Load."
+  #   ruleset: "checkgroup_parameters:cpu_load"
+  #   rule:
+  #     location:
+  #       folder: "/"
+  #       position: "bottom"
+  #     conditions: {
+  #       "host_labels": [],
+  #       "host_tags": [],
+  #       "service_labels": []
+  #     }
+  #     properties: {
+  #       "comment": "{{ ansible_date_time.iso8601 }} - Ansible managed",
+  #       "description": "",
+  #       "disabled": false
+  #     }
+  #     value_raw: "{'levels15': (1.0, 2.0)}"
 
   - name: "CPU - Utilization."
     ruleset: "checkgroup_parameters:cpu_iowait"


### PR DESCRIPTION
Remove a certain ruleset from the integration test due to incompatibity between Checkmk versions.

<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the idempotency for  the ruleset "checkgroup_parameters:cpu_load" cannot generically be tested for multiple Checkmk versions.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- We removed that particular ruleset from the list.
- Once, 2.2.0 is no EOL, we will reactivate this test, again.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
