### PR TITLE
Fix test for discovery module and change state to only_service_labels

### DIFF
--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -40,7 +40,7 @@ options:
         description: The action to perform during discovery.
         type: str
         default: new
-        choices: [new, remove, fix_all, refresh, tabula_rasa, only_host_labels, update_service_labels, monitor_undecided_services]
+        choices: [new, remove, fix_all, refresh, tabula_rasa, only_host_labels, only_service_labels, monitor_undecided_services]
     do_full_scan:
         description: The option whether to perform a full scan or not. (Bulk mode only).
         type: bool
@@ -255,7 +255,7 @@ class newBulkDiscoveryAPI(CheckmkAPI):
             options["monitor_undecided_services"] = True
         if self.params.get("state") in ["remove", "fix_all"]:
             options["remove_vanished_services"] = True
-        if self.params.get("state") in ["update_service_labels"]:
+        if self.params.get("state") in ["only_service_labels"]:
             options["update_service_labels"] = True
         if self.params.get("state") in ["new", "fix_all", "only_host_labels"]:
             options["update_host_labels"] = True
@@ -336,7 +336,7 @@ def run_module():
                 "refresh",
                 "tabula_rasa",
                 "only_host_labels",
-                "update_service_labels",
+                "only_service_labels",
                 "monitor_undecided_services",
             ],
         ),
@@ -400,7 +400,7 @@ def run_module():
         module.params["state"] = "refresh"
 
     if module.params.get("state") in [
-        "update_service_labels",
+        "only_service_labels",
         "monitor_undecided_services",
     ]:
         if ver < CheckmkVersion("2.3.0"):
@@ -426,7 +426,7 @@ def run_module():
                 module.fail_json(**result_as_dict(result))
             if module.params.get(
                 "state"
-            ) == "update_service_labels" and ver < CheckmkVersion("2.3.0p3"):
+            ) == "only_service_labels" and ver < CheckmkVersion("2.3.0p3"):
                 result = RESULT(
                     http_code=0,
                     msg="State can only be used in bulk mode",

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -72,7 +72,7 @@
         automation_user: "{{ checkmk_var_automation_user }}"
         automation_secret: "{{ checkmk_var_automation_secret }}"
         host_name: "{{ item.name }}"
-        state: "update_service_labels"
+        state: "only_service_labels"
       delegate_to: localhost
       run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_hosts }}"
@@ -95,19 +95,17 @@
       failed_when: "'State is not supported before 2.3.0' not in monitorundecidedservices_output.msg"
       when: "not '2.3.0' in outer_item.version"      
 
-    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update service labels. (Should fail in 2.3.0)"
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update service labels."
       discovery:
         server_url: "{{ checkmk_var_server_url }}"
         site: "{{ outer_item.site }}"
         automation_user: "{{ checkmk_var_automation_user }}"
         automation_secret: "{{ checkmk_var_automation_secret }}"
         host_name: "{{ item.name }}"
-        state: "update_service_labels"
+        state: "only_service_labels"
       delegate_to: localhost
       run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_hosts }}"
-      register: stableupdateservicelabels_output
-      failed_when: "'State can only be used in bulk mode' not in stableupdateservicelabels_output.msg"
       when: "'2.3.0' in outer_item.version"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Monitor undecided services. (Should fail in 2.3.0)"
@@ -245,7 +243,7 @@
         automation_user: "{{ checkmk_var_automation_user }}"
         automation_secret: "{{ checkmk_var_automation_secret }}"
         hosts: "{{ checkmk_host_names }}"
-        state: "update_service_labels"
+        state: "only_service_labels"
         bulk_size: 5
       delegate_to: localhost
       register: bulkupdateservicelabels_output
@@ -273,7 +271,7 @@
         automation_user: "{{ checkmk_var_automation_user }}"
         automation_secret: "{{ checkmk_var_automation_secret }}"
         hosts: "{{ checkmk_host_names }}"
-        state: "update_service_labels"
+        state: "only_service_labels"
         bulk_size: 5
       delegate_to: localhost
       when: "'2.3.0' in outer_item.version"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Testing against 2.3.0p3 with only_service_labels option for the single service discovery is now possible
- Tests are failing anyway, because this was initially introduced as "update_service_labels"

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed state from "update_service_labels" to "only_service_labels"
- Changed tests so they work with 2.3.0p3

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
