### PR TITLE
Allow registering on a http subsite with a https central site.

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -4,6 +4,7 @@ checkmk_agent_edition: cre
 checkmk_agent_server_protocol: http
 checkmk_agent_server: localhost
 checkmk_agent_site: mysite
+checkmk_agent_registration_server_protocol: "{{ checkmk_agent_server_protocol }}"
 checkmk_agent_registration_server: "{{ checkmk_agent_server }}"
 checkmk_agent_registration_site: "{{ checkmk_agent_site }}"
 checkmk_agent_server_validate_certs: 'true'

--- a/roles/agent/molecule/2.1.0/group_vars/all.yml
+++ b/roles/agent/molecule/2.1.0/group_vars/all.yml
@@ -12,6 +12,7 @@ checkmk_agent_edition: "{{ checkmk_var_edition }}"
 checkmk_agent_server_protocol: http
 checkmk_agent_server: 127.0.0.1
 checkmk_agent_site: "{{ checkmk_var_checkmk_site }}"
+checkmk_agent_registration_server_protocol: "{{ checkmk_agent_server_protocol }}"
 checkmk_agent_registration_server: "{{ checkmk_agent_server }}"
 checkmk_agent_registration_site: "{{ checkmk_agent_site }}"
 checkmk_agent_server_validate_certs: 'false'

--- a/roles/agent/molecule/2.2.0/group_vars/all.yml
+++ b/roles/agent/molecule/2.2.0/group_vars/all.yml
@@ -12,6 +12,7 @@ checkmk_agent_edition: "{{ checkmk_var_edition }}"
 checkmk_agent_server_protocol: http
 checkmk_agent_server: 127.0.0.1
 checkmk_agent_site: "{{ checkmk_var_checkmk_site }}"
+checkmk_agent_registration_server_protocol: "{{ checkmk_agent_server_protocol }}"
 checkmk_agent_registration_server: "{{ checkmk_agent_server }}"
 checkmk_agent_registration_site: "{{ checkmk_agent_site }}"
 checkmk_agent_server_validate_certs: 'false'

--- a/roles/agent/molecule/2.3.0/group_vars/all.yml
+++ b/roles/agent/molecule/2.3.0/group_vars/all.yml
@@ -12,6 +12,7 @@ checkmk_agent_edition: "{{ checkmk_var_edition }}"
 checkmk_agent_server_protocol: http
 checkmk_agent_server: 127.0.0.1
 checkmk_agent_site: "{{ checkmk_var_checkmk_site }}"
+checkmk_agent_registration_server_protocol: "{{ checkmk_agent_server_protocol }}"
 checkmk_agent_registration_server: "{{ checkmk_agent_server }}"
 checkmk_agent_registration_site: "{{ checkmk_agent_site }}"
 checkmk_agent_server_validate_certs: 'false'

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -106,7 +106,7 @@
   become: true
   ansible.builtin.shell: |
     cmk-update-agent register -H {{ checkmk_agent_host_name }} \
-    -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_server_protocol }} \
+    -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_registration_server_protocol }} \
     -U {{ checkmk_agent_user }} -P {{ __checkmk_agent_auth }}
   no_log: "{{ checkmk_agent_no_log | bool }}"
   register: __checkmk_agent_update_state
@@ -122,7 +122,7 @@
   become: true
   ansible.builtin.shell: |
     cmk-update-agent register -H {{ checkmk_agent_host_name }} \
-    -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_server_protocol }} \
+    -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_registration_server_protocol }} \
     -U {{ checkmk_agent_user }} -S {{ __checkmk_agent_auth }}
   no_log: "{{ checkmk_agent_no_log | bool }}"
   register: __checkmk_agent_update_state

--- a/roles/agent/tasks/Win32NT.yml
+++ b/roles/agent/tasks/Win32NT.yml
@@ -74,7 +74,7 @@
 - name: "{{ ansible_system }}: Register Agent for automatic Updates using Automation Secret."  # noqa no-changed-when
   ansible.windows.win_command: |
     check_mk_agent.exe updater register -H {{ checkmk_agent_host_name }} \
-    -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_server_protocol }} \
+    -s {{ checkmk_agent_registration_server }} -i {{ checkmk_agent_registration_site }} -p {{ checkmk_agent_registration_server_protocol }} \
     -U {{ checkmk_agent_user }} -S {{ __checkmk_agent_auth }}
   no_log: "{{ checkmk_agent_no_log | bool }}"
   register: __checkmk_agent_update_state


### PR DESCRIPTION
Currently the variable `checkmk_agent_server_protocol` is used both for downloading the agent at the central site, and for registering the agent at the subsite, therefore making it mandatory to use http or https on both sites without mixing.

Introduces a new variable `checkmk_agent_registration_server_protocol` which defaults to `checkmk_agent_server_protocol`, similar to the other `checkmk_agent_registration_*` variables to solve that.

<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The variable `checkmk_agent_server_protocol` is used to specify http or https both for downloading the agent at the central site and for registering the agent at any subsite.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `checkmk_agent_server_protocol` is used to specify http or https for downloading the agent
- `checkmk_agent_registration_protocol` is used to specify http or https depending on what the subsite requires
- `checkmk_agent_registration_protocol` defaults to `{{ checkmk_agent_server_protocol }}`, thereby not changing any existing behaviour

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
