### PR TITLE
Make discovery module compatible to Checkmk 2.4.0.

### DIFF
--- a/.github/workflows/ans-int-test-discovery.yaml
+++ b/.github/workflows/ans-int-test-discovery.yaml
@@ -81,7 +81,7 @@ jobs:
         ports:
           - 5323:5000
         env:
-          CMK_SITE_ID: "stable_cme"
+          CMK_SITE_ID: "old_cme"
           CMK_PASSWORD: "Sup3rSec4et!"
       stable_cre:
         image: checkmk/check-mk-raw:2.4.0-daily

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -240,13 +240,23 @@ class newBulkDiscoveryAPI(CheckmkAPI):
             "update_host_labels": False,
         }
 
-        if self.params.get("state") in ["new", "fix_all", "monitor_undecided_services", "refresh"]:
+        if self.params.get("state") in [
+            "new", 
+            "fix_all", 
+            "monitor_undecided_services", 
+            "refresh"
+        ]:
             options["monitor_undecided_services"] = True
         if self.params.get("state") in ["remove", "fix_all", "refresh"]:
             options["remove_vanished_services"] = True
         if self.params.get("state") in ["only_service_labels", "refresh"]:
             options["update_service_labels"] = True
-        if self.params.get("state") in ["new", "fix_all", "only_host_labels", "refresh"]:
+        if self.params.get("state") in [
+            "new", 
+            "fix_all", 
+            "only_host_labels", 
+            "refresh"
+        ]:
             options["update_host_labels"] = True
 
         data = {
@@ -358,7 +368,6 @@ def run_module():
         servicecompletion = ServiceCompletionAPI(module)
     else:
         discovery = BulkDiscoveryAPI(module)
-        print("### Using BulkDiscoveryAPI")
         servicecompletion = ServiceCompletionBulkAPI(module)
 
     ver = discovery.getversion()
@@ -419,7 +428,6 @@ def run_module():
                 module.fail_json(**result_as_dict(result))
 
     if not single_mode and ver >= CheckmkVersion("2.3.0"):
-        print("### Using newBulkDiscoveryAPI")
         discovery = newBulkDiscoveryAPI(module)
 
     result = wait_for_completion(single_mode, servicecompletion)

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -244,7 +244,7 @@ class newBulkDiscoveryAPI(CheckmkAPI):
             "new",
             "fix_all",
             "monitor_undecided_services",
-            "refresh"
+            "refresh",
         ]:
             options["monitor_undecided_services"] = True
         if self.params.get("state") in ["remove", "fix_all", "refresh"]:
@@ -255,7 +255,7 @@ class newBulkDiscoveryAPI(CheckmkAPI):
             "new",
             "fix_all",
             "only_host_labels",
-            "refresh"
+            "refresh",
         ]:
             options["update_host_labels"] = True
 

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -37,7 +37,12 @@ options:
         elements: str
         default: []
     state:
-        description: The action to perform during discovery.
+        description:
+            - The action to perform during discovery.
+            - Not all choices are available with all Checkmk versions.
+            - Check the ReDoc documentation in your site for details.
+            - In versions 2.4.0 and newer, the modes tabula_rasa and refresh are no longer available,
+            - in that case, we perform a add/remove all services and labels, instead.
         type: str
         default: new
         choices: [new, remove, fix_all, refresh, tabula_rasa, only_host_labels, only_service_labels, monitor_undecided_services]
@@ -235,31 +240,22 @@ class newBulkDiscoveryAPI(CheckmkAPI):
             "update_host_labels": False,
         }
 
-        if self.params.get("state") in ["new", "fix_all", "monitor_undecided_services"]:
+        if self.params.get("state") in ["new", "fix_all", "monitor_undecided_services", "refresh"]:
             options["monitor_undecided_services"] = True
-        if self.params.get("state") in ["remove", "fix_all"]:
+        if self.params.get("state") in ["remove", "fix_all", "refresh"]:
             options["remove_vanished_services"] = True
-        if self.params.get("state") in ["only_service_labels"]:
+        if self.params.get("state") in ["only_service_labels", "refresh"]:
             options["update_service_labels"] = True
-        if self.params.get("state") in ["new", "fix_all", "only_host_labels"]:
+        if self.params.get("state") in ["new", "fix_all", "only_host_labels", "refresh"]:
             options["update_host_labels"] = True
 
-        if self.params.get("state") == "refresh":
-            data = {
-                "hostnames": self.params.get("hosts", []),
-                "mode": self.params.get("state"),
-                "do_full_scan": self.params.get("do_full_scan", True),
-                "bulk_size": self.params.get("bulk_size", 1),
-                "ignore_errors": self.params.get("ignore_errors", True),
-            }
-        else:
-            data = {
-                "hostnames": self.params.get("hosts", []),
-                "options": options,
-                "do_full_scan": self.params.get("do_full_scan", True),
-                "bulk_size": self.params.get("bulk_size", 1),
-                "ignore_errors": self.params.get("ignore_errors", True),
-            }
+        data = {
+            "hostnames": self.params.get("hosts", []),
+            "options": options,
+            "do_full_scan": self.params.get("do_full_scan", True),
+            "bulk_size": self.params.get("bulk_size", 1),
+            "ignore_errors": self.params.get("ignore_errors", True),
+        }
 
         return self._fetch(
             code_mapping=HTTP_CODES_BULK,
@@ -362,12 +358,13 @@ def run_module():
         servicecompletion = ServiceCompletionAPI(module)
     else:
         discovery = BulkDiscoveryAPI(module)
+        print("### Using BulkDiscoveryAPI")
         servicecompletion = ServiceCompletionBulkAPI(module)
 
     ver = discovery.getversion()
 
-    if single_mode and ver < CheckmkVersion("2.1.0"):
-        discovery = oldDiscoveryAPI(module)
+    # if single_mode and ver < CheckmkVersion("2.1.0"):
+    #     discovery = oldDiscoveryAPI(module)
 
     if ver < CheckmkVersion("2.2.0") and module.params.get("state") == "tabula_rasa":
         result = RESULT(
@@ -422,6 +419,7 @@ def run_module():
                 module.fail_json(**result_as_dict(result))
 
     if not single_mode and ver >= CheckmkVersion("2.3.0"):
+        print("### Using newBulkDiscoveryAPI")
         discovery = newBulkDiscoveryAPI(module)
 
     result = wait_for_completion(single_mode, servicecompletion)

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -372,9 +372,6 @@ def run_module():
 
     ver = discovery.getversion()
 
-    # if single_mode and ver < CheckmkVersion("2.1.0"):
-    #     discovery = oldDiscoveryAPI(module)
-
     if ver < CheckmkVersion("2.2.0") and module.params.get("state") == "tabula_rasa":
         result = RESULT(
             http_code=0,

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -241,9 +241,9 @@ class newBulkDiscoveryAPI(CheckmkAPI):
         }
 
         if self.params.get("state") in [
-            "new", 
-            "fix_all", 
-            "monitor_undecided_services", 
+            "new",
+            "fix_all",
+            "monitor_undecided_services",
             "refresh"
         ]:
             options["monitor_undecided_services"] = True
@@ -252,9 +252,9 @@ class newBulkDiscoveryAPI(CheckmkAPI):
         if self.params.get("state") in ["only_service_labels", "refresh"]:
             options["update_service_labels"] = True
         if self.params.get("state") in [
-            "new", 
-            "fix_all", 
-            "only_host_labels", 
+            "new",
+            "fix_all",
+            "only_host_labels",
             "refresh"
         ]:
             options["update_host_labels"] = True

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -9,6 +9,19 @@
     checkmk_var_customer: null
   when: outer_item.edition != "cme"
 
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check REST API."
+  ansible.builtin.uri:
+    url: "{{ checkmk_var_server_url }}/{{ outer_item.site }}/check_mk/api/1.0/version"
+    headers: 
+      Accept: application/json
+      Authorization: "Bearer {{ checkmk_var_automation_user }} {{ checkmk_var_automation_secret }}"
+    register: result
+    ignore_errors: yes
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - REST Result."
+  ansible.builtin.debug:
+    var: result
+
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
   host:
     server_url: "{{ checkmk_var_server_url }}"

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -9,6 +9,26 @@
     checkmk_var_customer: null
   when: outer_item.edition != "cme"
 
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check Apache."
+  ansible.builtin.uri:
+    url: "{{ checkmk_var_server_url }}"
+  register: result
+  ignore_errors: yes
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Apache Result."
+  ansible.builtin.debug:
+    var: result
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check UI."
+  ansible.builtin.uri:
+    url: "{{ checkmk_var_server_url }}"
+  register: result
+  ignore_errors: yes
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - UI Result."
+  ansible.builtin.debug:
+    var: result
+
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check REST API."
   ansible.builtin.uri:
     url: "{{ checkmk_var_server_url }}/{{ outer_item.site }}/check_mk/api/1.0/version"

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -9,39 +9,6 @@
     checkmk_var_customer: null
   when: outer_item.edition != "cme"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check Apache."
-  ansible.builtin.uri:
-    url: "{{ checkmk_var_server_url }}"
-  register: result
-  ignore_errors: yes
-
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Apache Result."
-  ansible.builtin.debug:
-    var: result
-
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check UI."
-  ansible.builtin.uri:
-    url: "{{ checkmk_var_server_url }}"
-  register: result
-  ignore_errors: yes
-
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - UI Result."
-  ansible.builtin.debug:
-    var: result
-
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check REST API."
-  ansible.builtin.uri:
-    url: "{{ checkmk_var_server_url }}/{{ outer_item.site }}/check_mk/api/1.0/version"
-    headers: 
-      Accept: application/json
-      Authorization: "Bearer {{ checkmk_var_automation_user }} {{ checkmk_var_automation_secret }}"
-  register: result
-  ignore_errors: yes
-
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - REST Result."
-  ansible.builtin.debug:
-    var: result
-
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
   host:
     server_url: "{{ checkmk_var_server_url }}"

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -15,8 +15,8 @@
     headers: 
       Accept: application/json
       Authorization: "Bearer {{ checkmk_var_automation_user }} {{ checkmk_var_automation_secret }}"
-    register: result
-    ignore_errors: yes
+  register: result
+  ignore_errors: yes
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - REST Result."
   ansible.builtin.debug:


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #709 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- In versions 2.4.0 and newer, the modes tabula_rasa and refresh are no longer available,
 in that case, we perform a add/remove all services and labels, instead.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
The API parameter mode is gone for the bulk discovery endpoint in Checkmk 2.4.0. In 2.3.0 it was already deprecated. Instead, the parameter "mode" was introduced. Thus, we use this mapping:
| State                       | monitor_undecided_services | remove_vanished_services | update_service_labels | update_host_labels |
| --------------------------- | -------------------------- | ------------------------ | --------------------- | ------------------ |
| new                         | X                          |                          |                       | X                  |
| fix_all                     | X                          | X                        |                       | X                  |
| monitor_undecided_services  | X                          |                          |                       |                    |
| refresh                     | X                          | X                        | X                     | X                  |
| tabula_rasa                 | X                          | X                        | X                     | X                  |
| only_service_labels         |                            |                          | X                     |                    |
| only_host_labels            |                            |                          |                       | X                  |
| remove                      |                            | X                        |                       |                    |