### PR TITLE
Tmp directory variable for server role

### DIFF
--- a/roles/server/tasks/Debian.yml
+++ b/roles/server/tasks/Debian.yml
@@ -3,7 +3,7 @@
   when: not 'check-mk-' + __checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
   become: true
   ansible.builtin.apt:
-    deb: "/tmp/{{ __checkmk_server_setup_file }}"
+    deb: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
     update_cache: 'yes'
     state: present
   notify: Start Apache

--- a/roles/server/tasks/RedHat.yml
+++ b/roles/server/tasks/RedHat.yml
@@ -7,7 +7,7 @@
     - name: "Download EPEL GPG Key on CentOS & RHEL 8."
       ansible.builtin.get_url:
         url: "{{ __checkmk_server_epel_gpg_key }}"
-        dest: "/tmp/EPEL-pubkey.gpg"
+        dest: "{{ __checkmk_server_tmp_dir }}/EPEL-pubkey.gpg"
         mode: "0640"
       when: checkmk_server_verify_setup | bool
       tags:
@@ -17,7 +17,7 @@
     - name: "Import Checkmk GPG Key on RHEL 8."
       become: true
       ansible.builtin.rpm_key:
-        key: "/tmp/EPEL-pubkey.gpg"
+        key: "{{ __checkmk_server_tmp_dir }}/EPEL-pubkey.gpg"
         state: present
       when: checkmk_server_epel_gpg_check | bool
       tags:
@@ -80,7 +80,7 @@
   when: not 'check-mk-' + __checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts.packages
   become: true
   ansible.builtin.dnf:
-    name: "/tmp/{{ __checkmk_server_setup_file }}"
+    name: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
     state: present
     disable_gpg_check: '{{ not checkmk_server_verify_setup | bool }}'
   notify: Start httpd

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -44,7 +44,7 @@
     - name: "Download Checkmk Server Setup."
       ansible.builtin.get_url:
         url: "{{ checkmk_server_download_url }}"
-        dest: "/tmp/{{ __checkmk_server_setup_file }}"
+        dest: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
         mode: "0640"
         url_username: "{{ checkmk_server_download_user | default(omit) }}"
         url_password: "{{ checkmk_server_download_pass | default(omit) }}"
@@ -55,7 +55,7 @@
     - name: "Download Checkmk GPG Key."
       ansible.builtin.get_url:
         url: "https://download.checkmk.com/checkmk/Check_MK-pubkey.gpg"
-        dest: "/tmp/Check_MK-pubkey.gpg"
+        dest: "{{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
         mode: "0640"
       when: checkmk_server_verify_setup | bool
       retries: 3
@@ -66,7 +66,7 @@
       when: checkmk_server_verify_setup | bool and ansible_os_family == "Debian"
       block:
         - name: "Import Checkmk GPG Key."
-          ansible.builtin.command: "gpg --import /tmp/Check_MK-pubkey.gpg"
+          ansible.builtin.command: "gpg --import {{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
           register: __checkmk_server_gpg_import
           when: checkmk_server_verify_setup | bool
           changed_when: "'imported: 1' in __checkmk_server_gpg_import"
@@ -74,7 +74,7 @@
             - import-gpg-key
 
         - name: "Verify Checkmk Setup."
-          ansible.builtin.command: gpg --verify "/tmp/{{ __checkmk_server_setup_file }}"
+          ansible.builtin.command: gpg --verify "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
           register: __checkmk_server_verify_state
           changed_when: false
           failed_when: "'Bad signature' in __checkmk_server_verify_state.stderr"
@@ -82,7 +82,7 @@
     - name: "Import Checkmk GPG Key."
       become: true
       ansible.builtin.rpm_key:
-        key: "/tmp/Check_MK-pubkey.gpg"
+        key: "{{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
         state: present
       when: checkmk_server_verify_setup | bool and ansible_os_family == "RedHat"
       tags:

--- a/roles/server/vars/main.yml
+++ b/roles/server/vars/main.yml
@@ -9,3 +9,5 @@ __checkmk_server_edition_mapping:
   cee: enterprise
   cce: cloud
   cme: managed
+
+__checkmk_server_tmp_dir: "/tmp"


### PR DESCRIPTION
Add a variable in the server role to standardize the temporary directory for server installation and configuration.

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

- Centralization of detail configuration
- Role users could specify their own temporary directory

## Other information
Mentioned by @robin-checkmk in  #714 
