### PR TITLE
Make gpg key download url configurable

### DIFF
--- a/changelogs/fragments/gpg.yml
+++ b/changelogs/fragments/gpg.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Server role - Make GPG key download URL configurable.

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -54,7 +54,7 @@
 
     - name: "Download Checkmk GPG Key."
       ansible.builtin.get_url:
-        url: "https://download.checkmk.com/checkmk/Check_MK-pubkey.gpg"
+        url: "{{ checkmk_server_gpg_download_url }}"
         dest: "{{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
         mode: "0640"
       when: checkmk_server_verify_setup | bool

--- a/roles/server/vars/main.yml
+++ b/roles/server/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 __checkmk_server_base_url: "https://download.checkmk.com/checkmk"
 checkmk_server_download_url: "{{ __checkmk_server_base_url }}/{{ checkmk_server_version }}/{{ __checkmk_server_setup_file }}"
+checkmk_server_gpg_download_url: "{{ __checkmk_server_base_url }}/Check_MK-pubkey.gpg"
 
 # Due to inconsistent naming of editions, we normalize them here for convenience
 __checkmk_server_edition_mapping:


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When installing the CheckMK server on a backend system with no access to the internet via a local mirror, the downloaded package can not be verified via the gpg key. The role tries to download the gpg key from https://download.checkmk.com/checkmk even if another mirror is used. This leads to the necessary deactivation of `checkmk_server_verify_setup` if `checkmk_server_download_url` is overwritten. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduction of the variable `checkmk_server_gpg_download_url` which is set to `{{ __checkmk_server_base_url }}/Check_MK-pubkey.gpg`
- If the `checkmk_server_download_url` needs to be modified the `checkmk_server_gpg_download_url` can be updated too.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->

This change makes the *verified* installation on systems without internet access possible.