### PR TITLE
User role: No longer allow to change the user that is used for API authorization.

### DIFF
--- a/changelogs/fragments/user.yml
+++ b/changelogs/fragments/user.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - User role - No longer allow to change the user that is used for API authorization.
+  - User role - No longer allow to modify the user that is used for API authorization.

--- a/changelogs/fragments/user.yml
+++ b/changelogs/fragments/user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - User role - No longer allow to change the user that is used for API authorization.

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -507,6 +507,18 @@ def run_module():
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
+    if module.params.get("automation_user") == module.params.get("name"):
+        result = RESULT(
+            http_code=0,
+            msg="Can't modify the user that is used for API authorization."
+            content="",
+            etag="",
+            failed=True,
+            changed=False,
+        )
+        module.exit_json(**result_as_dict(result))
+
+
     # Use the parameters to initialize some common api variables
     user = UserAPI(module)
 

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -518,7 +518,6 @@ def run_module():
         )
         module.exit_json(**result_as_dict(result))
 
-
     # Use the parameters to initialize some common api variables
     user = UserAPI(module)
 

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -510,7 +510,7 @@ def run_module():
     if module.params.get("automation_user") == module.params.get("name"):
         result = RESULT(
             http_code=0,
-            msg="Can't modify the user that is used for API authorization."
+            msg="You cannot modify the user that is used for API authorization",
             content="",
             etag="",
             failed=True,

--- a/tests/integration/targets/user/tasks/test.yml
+++ b/tests/integration/targets/user/tasks/test.yml
@@ -160,7 +160,7 @@
   delegate_to: localhost
   run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_dont_edit
-  failed_when: "'Will not modify the user that is used' not in __checkmk_var_result_dont_edit.msg"
+  failed_when: "'You cannot modify the user that is used for API' not in __checkmk_var_result_dont_edit.msg"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:

--- a/tests/integration/targets/user/tasks/test.yml
+++ b/tests/integration/targets/user/tasks/test.yml
@@ -147,6 +147,21 @@
   run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_users_edit }}"
 
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Don't edit auth user."
+  user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    automation_user: "{{ checkmk_var_automation_user }}"
+    automation_secret: "{{ checkmk_var_automation_secret }}"
+    customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
+    name: "{{ checkmk_var_automation_user }}"
+    show_mode: "enforce_show_more"
+    state: "present"
+  delegate_to: localhost
+  run_once: true  # noqa run-once[task]
+  register: __checkmk_var_result_dont_edit
+  failed_when: "'Will not modify the user that is used' not in __checkmk_var_result_dont_edit.msg"
+
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:
     server_url: "{{ checkmk_var_server_url }}"

--- a/tests/integration/targets/user/vars/main.yml
+++ b/tests/integration/targets/user/vars/main.yml
@@ -195,8 +195,3 @@ checkmk_var_users_edit:
     contactgroups: []
     roles:
       - admin
-  - name: cmkadmin
-    show_mode: "enforce_show_more"
-    fullname: cmkadmin
-    roles:
-      - admin


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

From 2.4.0 on, the etag of a user changes with every API call, if the user is also used for API auth.
This made it impossible to e.g. change the cmkadmin user when authorizing against the API as cmkadmin.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The user module now prevents from using the same user for auth that you are actually changing.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
