### PR TITLE
Feature ansible host for inventory

### DIFF
--- a/changelogs/fragments/feature_ansible_host_for_inventory.yml
+++ b/changelogs/fragments/feature_ansible_host_for_inventory.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - Dynamic Inventory Source - Add possibility to update ansible_host with ip address from Checkmk

--- a/plugins/inventory/checkmk.py
+++ b/plugins/inventory/checkmk.py
@@ -30,7 +30,7 @@ DOCUMENTATION = """
             elements: str
             required: false
         want_ipv4:
-            description: Update ansible_host variable with ip address from Checkmk instead of DNS
+            description: Update ansible_host variable with ip address from Checkmk
             type: boolean
             required: false
 """

--- a/plugins/inventory/checkmk.py
+++ b/plugins/inventory/checkmk.py
@@ -29,6 +29,10 @@ DOCUMENTATION = """
             type: list
             elements: str
             required: false
+        want_ipv4:
+            description: Update ansible_host variable with ip address from Checkmk instead of DNS
+            type: boolean
+            required: false
 """
 
 EXAMPLES = """
@@ -44,6 +48,7 @@ automation_user: "cmkadmin"
 automation_secret: "******"
 validate_certs: False
 groupsources: ["hosttags", "sites"]
+want_ipv4: False
 """
 
 import json
@@ -73,6 +78,7 @@ class InventoryModule(BaseInventoryPlugin):
         self.user = None
         self.secret = None
         self.validate_certs = None
+        self.want_ipv4 = None
         self.groupsources = []
         self.hosttaggroups = []
         self.tags = []
@@ -141,6 +147,7 @@ class InventoryModule(BaseInventoryPlugin):
             self.user = self.get_option("automation_user")
             self.secret = self.get_option("automation_secret")
             self.validate_certs = self.get_option("validate_certs")
+            self.want_ipv4 = self.get_option("want_ipv4")
             self.groupsources = self.get_option("groupsources")
         except Exception as e:
             raise AnsibleParserError("All correct options required: {}".format(e))
@@ -172,6 +179,8 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.add_host(host["id"])
             self.inventory.set_variable(host["id"], "ipaddress", host["ipaddress"])
             self.inventory.set_variable(host["id"], "folder", host["folder"])
+            if self.want_ipv4:
+                self.inventory.set_variable(host["id"], "ansible_host", host["ipaddress"])
 
         if self.groupsources:
             if "hosttags" in self.groupsources:

--- a/plugins/inventory/checkmk.py
+++ b/plugins/inventory/checkmk.py
@@ -180,7 +180,9 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.set_variable(host["id"], "ipaddress", host["ipaddress"])
             self.inventory.set_variable(host["id"], "folder", host["folder"])
             if self.want_ipv4:
-                self.inventory.set_variable(host["id"], "ansible_host", host["ipaddress"])
+                self.inventory.set_variable(
+                    host["id"], "ansible_host", host["ipaddress"]
+                )
 
         if self.groupsources:
             if "hosttags" in self.groupsources:


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->
This  merge request  adds a new option `want_ipv4` to Checkmk inventory plugin, which allows to update ansible_host variable. Therefor a connection to target hosts is possible via ip address instead of DNS. This option is not required, so users can decide whether to use ip or dns resolution.

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently DNS resolution is required for all hosts in Checkmk inventory, as ansible_host is not set.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Added option `want_ipv4` for DNS less Ansible connections by fetching the main ip address from Checkmk.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->

This fixes issue: #773 