### PR TITLE
Add support for optional GPG download credentials

### DIFF
--- a/changelogs/fragments/gpg_download_creds.yml
+++ b/changelogs/fragments/gpg_download_creds.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - server role - Add support for optional GPG credentials in the download process.

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -31,6 +31,8 @@ checkmk_server_verify_setup: 'true'
 
 checkmk_server_download_user: []
 checkmk_server_download_pass: []
+checkmk_server_gpg_download_user: []
+checkmk_server_gpg_download_pass: []
 
 checkmk_server_sites: []
 # - name: mysite

--- a/roles/server/meta/argument_specs.yml
+++ b/roles/server/meta/argument_specs.yml
@@ -37,6 +37,16 @@ argument_specs:
         description:
           - Refer to the README for details.
 
+      checkmk_server_gpg_download_user:
+        type: "str"
+        description:
+          - Refer to the README for details.
+
+      checkmk_server_gpg_download_pass:
+        type: "str"
+        description:
+          - Refer to the README for details.
+
       checkmk_server_sites:
         type: "list"
         elements: "dict"

--- a/roles/server/molecule/2.2.0/group_vars/all.yml
+++ b/roles/server/molecule/2.2.0/group_vars/all.yml
@@ -13,6 +13,8 @@ checkmk_server_version: "{{ checkmk_var_version }}"
 
 checkmk_server_download_user: []
 checkmk_server_download_pass: []
+checkmk_server_gpg_download_user: []
+checkmk_server_gpg_download_pass: []
 
 checkmk_server_sites:
   - name: "started"

--- a/roles/server/molecule/2.3.0/group_vars/all.yml
+++ b/roles/server/molecule/2.3.0/group_vars/all.yml
@@ -13,6 +13,8 @@ checkmk_server_version: "{{ checkmk_var_version }}"
 
 checkmk_server_download_user: []
 checkmk_server_download_pass: []
+checkmk_server_gpg_download_user: []
+checkmk_server_gpg_download_pass: []
 
 checkmk_server_sites:
   - name: "started"

--- a/roles/server/molecule/2.4.0/group_vars/all.yml
+++ b/roles/server/molecule/2.4.0/group_vars/all.yml
@@ -13,6 +13,8 @@ checkmk_server_version: "{{ checkmk_var_version }}"
 
 checkmk_server_download_user: []
 checkmk_server_download_pass: []
+checkmk_server_gpg_download_user: []
+checkmk_server_gpg_download_pass: []
 
 checkmk_server_sites:
   - name: "started"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -57,6 +57,8 @@
         url: "{{ checkmk_server_gpg_download_url }}"
         dest: "{{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
         mode: "0640"
+        url_username: "{{ checkmk_server_gpg_download_user | default(omit) }}"
+        url_password: "{{ checkmk_server_gpg_download_pass | default(omit) }}"
       when: checkmk_server_verify_setup | bool
       retries: 3
       tags:


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The variable `checkmk_server_gpg_download_url` offers the possibility to declare a custom URL where to download the Checkmk GPG public key from. However it is not possible to specify a username and password for this custom URL.
In a situation were there is no Internet access from the Checkmk site and only an access to a private repository, one may copy the key over to the repository. But the private repository might require credentials for download.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Using `checkmk_server_gpg_download_user` and `checkmk_server_gpg_download_pass`, it is possible to specify optional credentials for GPG public key download

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
