### PR TITLE
Add umount of tmpfs and Ignore error when updating site

### DIFF
--- a/changelogs/fragments/site_update.yml
+++ b/changelogs/fragments/site_update.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - server role - Add umount of tmpfs when updating site.
+    Ignore error when updating site to allow start of the site after aborted update.

--- a/roles/server/tasks/update-site.yml
+++ b/roles/server/tasks/update-site.yml
@@ -61,8 +61,10 @@
   become: true
   ansible.builtin.shell: |
     omd stop {{ item.item.name }}
+    umount -l $(mount -t tmpfs | grep /{{ item.item.name }}/ | tail -1 | awk '{print $3}') || true
     omd -f -V {{ item.item.version }}.{{ checkmk_server_edition | lower }} update --conflict {{ item.item.update_conflict_resolution }} {{ item.item.name }}
   args:
     executable: /bin/bash
   register: __checkmk_server_sites_updated
   changed_when: ("Finished update" in __checkmk_server_sites_updated.stdout)
+  ignore_errors: true


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Error handling

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the majority of site updates we perform manually, it is required to to manually unmount the temporary filesystem (tmpfs) after site stop. Command `omd umount` doesn't work (it keeps saying tmpfs is busy). It is required to execute command `umount -l` after `omd stop` to be able then to proceed with `omd update`. Due to this fact, the ansible playbook fails when running for site update.

The 2nd effect is that the site remains down after playbook fails, because the Start site task is not executed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- with the command `umount -l` added to the Update site task, the `omd update` will be executed without failing due tmpfs still mounted.
- if the `umount -l` fails for whatever reason, the `omd update` command will be executed anyway
- if the update process fails (i.e aborted), the playbook will continue and the Start site task can be executed

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
