### PR TITLE
Fix tags for server role

### DIFF
--- a/changelogs/fragments/fix_role_server_tags.yml
+++ b/changelogs/fragments/fix_role_server_tags.yml
@@ -1,0 +1,2 @@
+- bugfixes - Fix the server role tags.
+  Some existing tags are associated to additional existing tasks, in order to make the run of certain tasks working when executing playbook with tags.

--- a/changelogs/fragments/fix_role_server_tags.yml
+++ b/changelogs/fragments/fix_role_server_tags.yml
@@ -1,2 +1,3 @@
-- bugfixes - Fix the server role tags.
-  Some existing tags are associated to additional existing tasks, in order to make the run of certain tasks working when executing playbook with tags.
+bugfixes:
+  - Server role - Fix the server role tags.
+    Some existing tags are added to additional existing tasks, in order to make the run of certain tasks working when executing playbook with tags.

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -5,26 +5,37 @@
   when: (ansible_distribution is not defined) or
         (ansible_distribution_version is not defined) or
         (ansible_distribution + "-" + ansible_distribution_major_version not in checkmk_server_server_stable_os)
+  tags:
+    - always
 
 - name: "Preflight - Fail if Checkmk Edition is incorrect."
   ansible.builtin.fail:
     msg: "The provided Checkmk Edition '{{ checkmk_server_edition | lower }}' does  not exist or is not supported by this role."
   when: checkmk_server_edition | lower not in __checkmk_server_edition_mapping
+  tags:
+    - always
 
 - name: "Include OS Family specific Variables."
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   tags:
     - include-os-family-vars
     - install-package
+    - update-sites
 
 - name: "Get installed Packages."
   ansible.builtin.package_facts:
+  tags:
+    - install-package
+    - install-prerequisites
 
 - name: "Update APT Cache."
   become: true
   ansible.builtin.package:
     update_cache: true
   when: ansible_os_family == "Debian"
+  tags:
+    - install-package
+    - install-prerequisites
 
 - name: "Install Checkmk Prerequisites."
   become: true
@@ -78,6 +89,9 @@
           register: __checkmk_server_verify_state
           changed_when: false
           failed_when: "'Bad signature' in __checkmk_server_verify_state.stderr"
+          tags:
+            - download-package
+            - install-package
 
     - name: "Import Checkmk GPG Key."
       become: true
@@ -90,10 +104,14 @@
 
 - name: Include OS Family specific Playbook.
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
+  tags:
+    - always
 
 - name: Include Site Management Playbook.
   ansible.builtin.include_tasks: "sites.yml"
   when: checkmk_server_sites is defined
+  tags:
+    - always
 
 - name: "Cleanup unused Checkmk Versions."
   become: true
@@ -111,3 +129,5 @@
 - name: "Flush Handlers."
   ansible.builtin.meta:
     flush_handlers
+  tags:
+    - always

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -200,3 +200,5 @@
   changed_when: true
   notify: Warn site admin password
   no_log: "{{ checkmk_server_no_log | bool }}"
+  tags:
+    - create-sites

--- a/roles/server/tasks/update-site.yml
+++ b/roles/server/tasks/update-site.yml
@@ -4,6 +4,8 @@
     msg: |
       variable `update_conflict_resolution` is not given. See `omd update --help` for more information.
   when: item.item.update_conflict_resolution is undefined
+  tags:
+    - update-sites
 
 - name: "Check if desired version is installed."
   ansible.builtin.shell: |
@@ -13,6 +15,8 @@
     executable: /bin/bash
   register: __checkmk_server_sites_versions
   changed_when: false
+  tags:
+    - update-sites
 
 - name: "Fail if this is a downgrade."
   ansible.builtin.fail:
@@ -22,6 +26,8 @@
     checkmk_server_allow_downgrades is defined
     and not checkmk_server_allow_downgrades | bool
     and item.stdout is version(item.item.version, '>')
+  tags:
+    - update-sites
 
 - name: "Short pause for patch update."
   ansible.builtin.pause:
@@ -56,6 +62,8 @@
   args:
     executable: /bin/bash
   when: checkmk_server_backup_on_update
+  tags:
+    - update-sites
 
 - name: "Update Site."
   become: true
@@ -66,3 +74,5 @@
     executable: /bin/bash
   register: __checkmk_server_sites_updated
   changed_when: ("Finished update" in __checkmk_server_sites_updated.stdout)
+  tags:
+    - update-sites


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The usecase: executing the playbook server role for Checkmk **site update**, with tags, to avoid executing all tasks.
Using tags: `"download-package,download-gpg-key,import-gpg-key,install-package,update-sites,start-sites"`.
It is not working as some prerequisit tasks are missing:
- "Include OS Family specific Variables."
- "Get installed Packages."
- Include OS Family specific Playbook.
- Include Site Management Playbook
- "Flush Handlers."
- And the tasks in update-site.yml

Note: In this uscase, checkmk.general.role is included in another main playbook:
```yaml
- name: Update Checkmk site
  ansible.builtin.include_role:
    name: checkmk.general.server
  tags:
    - update-sites
```


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The tags for the tasks in role server have been reviewed to fix this.
- Add tag `always` to some tasks so that they are executed whatever tags are given to the playbook
- Add tag `update-sites` to all tasks required for updating site (in addition to the one with tag `always`)
- Add tags `install-package`, `install-prerequisites`, `download-package` wherever relevant
- Add tag `create-sites` to task related only to Create site (Trigger warning about missing cmkadmin password)

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
