### PR TITLE
Bugfix host creation for agent role

### DIFF
--- a/changelogs/fragments/agent.yml
+++ b/changelogs/fragments/agent.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - Agent role - The agent role now properly moves hosts based on the ``checkmk_agent_folder`` variable.
+    Before, there were two possible behaviors. Either the host was in the expected folder and its atrributes were updated if set.
+    Or the agent role would fail, if the host was in a different folder than defined in ``checkmk_agent_folder`` and had attributes set.
+    While the new behavior now actually is idempotent, it might be surprising, that hosts would be moved in the folder structure,
+    if the ``checkmk_agent_folder`` variable does not match the current folder of the host.
+    So while this is a bug fix by definition, please take note and check your configuration!

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -52,7 +52,7 @@
   tags:
     - include-os-family-tasks
 
-- name: "{{ ansible_system }}: Ensure Host is present in the right Folder."
+- name: "{{ ansible_system }}: Ensure Host is present in the correct Folder."
   checkmk.general.host:
     server_url: "{{ checkmk_agent_server_protocol }}://{{ checkmk_agent_server }}:{{ checkmk_agent_server_port }}/"
     site: "{{ checkmk_agent_site }}"

--- a/roles/agent/tasks/Win32NT.yml
+++ b/roles/agent/tasks/Win32NT.yml
@@ -5,7 +5,7 @@
     - include-os-family-tasks
 
 
-- name: "{{ ansible_system }}: Ensure Host is present."
+- name: "{{ ansible_system }}: Ensure Host is present in the correct Folder."
   checkmk.general.host:
     server_url: "{{ checkmk_agent_server_protocol }}://{{ checkmk_agent_server }}:{{ checkmk_agent_server_port }}/"
     site: "{{ checkmk_agent_site }}"


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #743 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The agent role now properly moves hosts based on the ``checkmk_agent_folder`` variable.
Before, there were two possible behaviors. Either the host was in the expected folder and its atrributes were updated if set. Or the agent role would fail, if the host was in a different folder than defined in ``checkmk_agent_folder`` and had attributes set. While the new behavior now actually is idempotent, it might be surprising, that hosts would be moved in the folder structure,if the ``checkmk_agent_folder`` variable does not match the current folder of the host. So while this is a bug fix by definition, please take note and check your configuration!

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->

## ToDo
- Add test case to molecule?
