### PR TITLE
Make Molecule use Podman as Driver

### DIFF
--- a/changelogs/template.yml
+++ b/changelogs/template.yml
@@ -16,7 +16,7 @@
 ## Line Format:
 # When writing a changelog entry, use the following format:
 # - scope - description starting with a uppercase letter and ending with a period at the very end. Multiple sentences are allowed.
-# The scope is usually a module or plugin name or group of modules or plugins, for example, lookup plugins.
+# The scope is usually a module or plugin name or group of modules or plugins, for example, "lookup plugins", "agent role" or "host lookup module".
 # While module names can (and should) be mentioned directly (foo_module), plugin names should always be followed by the type (foo inventory plugin).
 # For changes that are not really scoped (for example, which affect a whole collection), use the following format:
 # - Description starting with an uppercase letter and ending with a dot at the very end. Multiple sentences are allowed.
@@ -26,6 +26,9 @@
 # - Module name - This is a very long and detailed
 #   changelog line, so we will split it into several
 #   lines, just like this.
+#
+# Inline code blocks can be written as follows:
+# - my module - fix crash caused by ``cache.update()`` raising an ``IOError``
 
 ## Possible keys:
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ansible-lint
 jinja2
 molecule < 25.7.0
 molecule-plugins[docker]
+molecule-plugins[podman]
 yamllint
 pywinrm
 netaddr

--- a/roles/agent/molecule/2.2.0/molecule.yml
+++ b/roles/agent/molecule/2.2.0/molecule.yml
@@ -8,26 +8,31 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
 provisioner:
   name: ansible

--- a/roles/agent/molecule/2.2.0/molecule.yml
+++ b/roles/agent/molecule/2.2.0/molecule.yml
@@ -6,51 +6,41 @@ driver:
   name: podman
 platforms:
   - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
+    image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+    image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/agent/molecule/2.2.0/molecule.yml
+++ b/roles/agent/molecule/2.2.0/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible

--- a/roles/agent/molecule/2.2.0/molecule.yml
+++ b/roles/agent/molecule/2.2.0/molecule.yml
@@ -1,5 +1,4 @@
 ---
-# cgroupv2 support: https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
 dependency:
   name: galaxy
 driver:
@@ -8,42 +7,22 @@ platforms:
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/agent/molecule/2.2.0/molecule.yml
+++ b/roles/agent/molecule/2.2.0/molecule.yml
@@ -8,22 +8,27 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
 provisioner:
   name: ansible
   config_options:

--- a/roles/agent/molecule/2.3.0/molecule.yml
+++ b/roles/agent/molecule/2.3.0/molecule.yml
@@ -8,26 +8,31 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
 provisioner:
   name: ansible

--- a/roles/agent/molecule/2.3.0/molecule.yml
+++ b/roles/agent/molecule/2.3.0/molecule.yml
@@ -6,51 +6,41 @@ driver:
   name: podman
 platforms:
   - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
+    image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+    image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/agent/molecule/2.3.0/molecule.yml
+++ b/roles/agent/molecule/2.3.0/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible

--- a/roles/agent/molecule/2.3.0/molecule.yml
+++ b/roles/agent/molecule/2.3.0/molecule.yml
@@ -1,5 +1,4 @@
 ---
-# cgroupv2 support: https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
 dependency:
   name: galaxy
 driver:
@@ -8,42 +7,22 @@ platforms:
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/agent/molecule/2.3.0/molecule.yml
+++ b/roles/agent/molecule/2.3.0/molecule.yml
@@ -8,22 +8,27 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
 provisioner:
   name: ansible
   config_options:

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -8,26 +8,31 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
 provisioner:
   name: ansible

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -6,51 +6,41 @@ driver:
   name: podman
 platforms:
   - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
+    image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+    image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -1,5 +1,4 @@
 ---
-# cgroupv2 support: https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
 dependency:
   name: galaxy
 driver:
@@ -8,42 +7,22 @@ platforms:
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -8,22 +8,27 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
 provisioner:
   name: ansible
   config_options:

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -39,7 +39,7 @@ checkmk_server_sites: []
 #   version: "{{ checkmk_server_version }}"
 #   edition: "{{ checkmk_server_edition }}"
 #   state: started
-#   admin_pw: "{{ automation_secret | default(omit) }}"
+#   admin_pw: "{{ checkmk_var_automation_secret | default(omit) }}"
 #   update_conflict_resolution: abort
 #   omd_auto_restart: 'false'
 #   omd_config:

--- a/roles/server/molecule/2.2.0/molecule.yml
+++ b/roles/server/molecule/2.2.0/molecule.yml
@@ -8,26 +8,32 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
 provisioner:
   name: ansible
   config_options:

--- a/roles/server/molecule/2.2.0/molecule.yml
+++ b/roles/server/molecule/2.2.0/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ubuntu2004
     image: geerlingguy/docker-ubuntu2004-ansible

--- a/roles/server/molecule/2.2.0/molecule.yml
+++ b/roles/server/molecule/2.2.0/molecule.yml
@@ -6,61 +6,49 @@ driver:
   name: podman
 platforms:
   - name: ubuntu2004
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
+    image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+    image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/server/molecule/2.2.0/molecule.yml
+++ b/roles/server/molecule/2.2.0/molecule.yml
@@ -1,5 +1,4 @@
 ---
-# cgroupv2 support: https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
 dependency:
   name: galaxy
 driver:
@@ -8,50 +7,26 @@ platforms:
   - name: ubuntu2004
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/server/molecule/2.2.0/molecule.yml
+++ b/roles/server/molecule/2.2.0/molecule.yml
@@ -8,31 +8,37 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
 provisioner:
   name: ansible

--- a/roles/server/molecule/2.3.0/molecule.yml
+++ b/roles/server/molecule/2.3.0/molecule.yml
@@ -8,26 +8,32 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
 provisioner:
   name: ansible
   config_options:

--- a/roles/server/molecule/2.3.0/molecule.yml
+++ b/roles/server/molecule/2.3.0/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ubuntu2004
     image: geerlingguy/docker-ubuntu2004-ansible

--- a/roles/server/molecule/2.3.0/molecule.yml
+++ b/roles/server/molecule/2.3.0/molecule.yml
@@ -6,61 +6,49 @@ driver:
   name: podman
 platforms:
   - name: ubuntu2004
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
+    image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+    image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/server/molecule/2.3.0/molecule.yml
+++ b/roles/server/molecule/2.3.0/molecule.yml
@@ -1,5 +1,4 @@
 ---
-# cgroupv2 support: https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
 dependency:
   name: galaxy
 driver:
@@ -8,50 +7,26 @@ platforms:
   - name: ubuntu2004
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/server/molecule/2.3.0/molecule.yml
+++ b/roles/server/molecule/2.3.0/molecule.yml
@@ -8,31 +8,37 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
 provisioner:
   name: ansible

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -8,26 +8,31 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    privileged: true
     systemd: always
 provisioner:
   name: ansible

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -6,51 +6,41 @@ driver:
   name: podman
 platforms:
   - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: ubuntu2404
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian11
-    image: geerlingguy/docker-debian11-ansible
+    image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible
+    image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
   - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     cgroupns_mode: host
-    tmpfs:
-      - /run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -3,7 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ubuntu2204
     image: geerlingguy/docker-ubuntu2204-ansible

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -1,5 +1,4 @@
 ---
-# cgroupv2 support: https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
 dependency:
   name: galaxy
 driver:
@@ -8,42 +7,22 @@ platforms:
   - name: ubuntu2204
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -8,22 +8,27 @@ platforms:
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
+    systemd: always
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
With this change we are getting rid of Docker for Molecule testing. This does not only match the strategy of relying on Podman, but also removes workarounds for and quirks of the Docker platform. 

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
