### PR TITLE
Bugfix/issue824

### DIFF
--- a/roles/server/tasks/mkp.yml
+++ b/roles/server/tasks/mkp.yml
@@ -28,9 +28,7 @@
     - manage-mkp-packages
 
 - name: "Install mkp packages."
-  become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
+  ansible.builtin.command: "/usr/bin/su - {{ __site.name }} -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
   changed_when: __checkmk_server_mkp_install_output.rc == 0
   failed_when: __checkmk_server_mkp_install_output.rc != 0 and 'exists on the site' not in __checkmk_server_mkp_install_output.stderr
   register: __checkmk_server_mkp_install_output
@@ -42,9 +40,7 @@
     - manage-mkp-packages
 
 - name: "Enable mkp packages."
-  become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
+  ansible.builtin.command: "/usr/bin/su - {{ __site.name }} -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_enable_output.rc == 0
   register: __checkmk_server_mkp_enable_output
   loop: "{{ __site.mkp_packages }}"
@@ -55,9 +51,7 @@
     - manage-mkp-packages
 
 - name: "Disable mkp packages."
-  become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
+  ansible.builtin.command: "/usr/bin/su - {{ __site.name }} -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_disable_output.rc == 0
   register: __checkmk_server_mkp_disable_output
   loop: "{{ __site.mkp_packages }}"
@@ -68,9 +62,7 @@
     - manage-mkp-packages
 
 - name: "Remove mkp packages."
-  become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
+  ansible.builtin.command: "/usr/bin/su - {{ __site.name }} -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_remove_output.rc == 0
   register: __checkmk_server_mkp_remove_output
   loop: "{{ __site.mkp_packages }}"


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When using playbooks that already use `become_user` the tasks to install MKPs do not work.

Issue Number: #824

## What is the new behavior?

Installation of MKPs works as the `mkp` call now runs as site user.

## Other information

I do not think that this special case violates Ansible's recommendation to use `become_user`. This cannot be used twice as reported in issue #824.