### PR TITLE
Change API call timeouts and retries to reduce potential server load

### DIFF
--- a/changelogs/fragments/api.yml
+++ b/changelogs/fragments/api.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - All modules - Change API call timeout to 60 seconds and retry to 1 to avoid server overload.
+    This is a temporary measure, as currently repeating the same expensive query on an already
+    overloaded server several times does actually worsen the situation. As soon as this is fixed
+    upstream, we will re-establish the original back-off mechanism.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -65,13 +65,13 @@ class CheckmkAPI:
 
         # retry if timed out and each time double the timeout value
         #
-        # The below values where changed from 3 retries with an
+        # The below values were changed from 3 retries with an
         # initial timeout of 10 seconds to 1 retry with a timeout
         # of 60 seconds.
         # The reasoning is this: The REST API will continue computing
         # a request, even if the client cancels it. So while the
         # initially implemented back-off mechanism makes sense, in
-        # our case it can actually make things worse. Hence the change.
+        # our case it can actually make things worse. Hence, the change.
         # TODO: If the REST API at some point actually cancels requests
         # properly, we can go back to the initial back-off mechanism.
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -64,8 +64,19 @@ class CheckmkAPI:
         http_mapping.update(code_mapping)
 
         # retry if timed out and each time double the timeout value
-        num_of_retries = 3
-        timeout = 10
+        #
+        # The below values where changed from 3 retries with an
+        # initial timeout of 10 seconds to 1 retry with a timeout
+        # of 60 seconds.
+        # The reasoning is this: The REST API will continue computing
+        # a request, even if the client cancels it. So while the
+        # initially implemented back-off mechanism makes sense, in
+        # our case it can actually make things worse. Hence the change.
+        # TODO: If the REST API at some point actually cancels requests
+        # properly, we can go back to the initial back-off mechanism.
+
+        num_of_retries = 1
+        timeout = 60
         for i in range(num_of_retries):
             response, info = fetch_url(
                 module=self.module,


### PR DESCRIPTION
The global timeout for API calls was 10 seconds, which was doubled with every retry (defaults to 3 retries).
On a heavily loaded server, this could lead to three API calls, one cancelled after 10 seconds, the second after 20 seconds and the last cancelled after 40 seconds. While these are cancelled on client-side, the server keeps computing the calls.

This pull request effectively disables this back-off mechanism by setting a timeout of 60 seconds and only one retry.

We want to re-enable it, as soon as the REST API actually cancels server-side actions when the client cancels them.
Until then, we hope that these changes will improve the situation in heavy-duty environments.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #830 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The global API timeout is raised to 60 seconds
- The number of retries is reduced to 1

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
