### PR TITLE
Clean up setup files after successful role execution

### DIFF
--- a/changelogs/fragments/setups.yml
+++ b/changelogs/fragments/setups.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Roles - Clean up setup files after successfull role execution.

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -229,3 +229,14 @@
   become: true
   ansible.builtin.command: cmk-agent-ctl push
   when: checkmk_agent_mode == 'push'
+
+- name: "Cleanup Checkmk Agent Setups."
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ __checkmk_agent_agent.file.cre }}"
+    - "{{ __checkmk_agent_agent.file.cee }}"
+    - "{{ __checkmk_agent_agent.file.host }}"
+  tags:
+    - download-package

--- a/roles/agent/tasks/Windows.yml
+++ b/roles/agent/tasks/Windows.yml
@@ -26,3 +26,14 @@
   when: checkmk_agent_edition | lower == "cre"
   tags:
     - install-package
+
+- name: "Cleanup Checkmk Agent Setups."
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ __checkmk_agent_agent.file.cre }}"
+    - "{{ __checkmk_agent_agent.file.cee }}"
+    - "{{ __checkmk_agent_agent.file.host }}"
+  tags:
+    - download-package

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -132,6 +132,13 @@
   tags:
     - cleanup
 
+- name: "Cleanup Checkmk Server Setup."
+  ansible.builtin.file:
+    path: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
+    state: absent
+  tags:
+    - download-package
+
 - name: "Flush Handlers."
   ansible.builtin.meta:
     flush_handlers


### PR DESCRIPTION
Clean up setup files after successful role execution.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Setup files both for the `agent` and `server` would be left in the `__checkmk_server_tmp_dir` location, which defaults to `/tmp`. This is not a problem, if one installs a few Checkmk versions (agent or server) between reboots. But there are two corner cases: One might reboot their servers very very rarely, or they might have disabled the automatic cleanup of `/tmp` on their system.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
With this PR we clean up the setup files for both the `agent` and `server` roles.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
