### PR TITLE
Clean up obsolete `failed_when` statements.

### DIFF
--- a/roles/agent/tasks/Linux-files.yml
+++ b/roles/agent/tasks/Linux-files.yml
@@ -68,6 +68,7 @@
     and checkmk_agent_folder is defined
     and not checkmk_agent_host_specific | bool
   retries: 3
+  # This task may fail, as we fall back to the generic agent in that case
   failed_when: 'false'
   changed_when: __checkmk_agent_folder_download_state.status is defined and __checkmk_agent_folder_download_state.status == 200
   delegate_to: "{{ checkmk_agent_delegate_download }}"

--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -64,9 +64,6 @@
     state: "present"
   become: false
   register: __checkmk_agent_create_result
-  failed_when: |
-    (__checkmk_agent_create_result.failed == true) and
-    ("The host is already part of the specified target folder" not in __checkmk_agent_create_result.msg)
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   when: checkmk_agent_add_host | bool
   notify: "Activate changes"
@@ -83,9 +80,6 @@
     state: "present"
   become: false
   register: __checkmk_agent_create_result
-  failed_when: |
-    (__checkmk_agent_create_result.failed == true) and
-    ("The host is already part of the specified target folder" not in __checkmk_agent_create_result.msg)
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   when: checkmk_agent_add_host | bool
   notify: "Activate changes"

--- a/roles/agent/tasks/Win32NT-files.yml
+++ b/roles/agent/tasks/Win32NT-files.yml
@@ -67,6 +67,7 @@
         and checkmk_agent_folder is defined
         and not checkmk_agent_host_specific | bool
       retries: 3
+      # This task may fail, as we fall back to the generic agent in that case
       failed_when: 'false'
       changed_when: __checkmk_agent_folder_download_state.status_code is defined and __checkmk_agent_folder_download_state.status_code == 200
       tags:
@@ -168,6 +169,7 @@
         and checkmk_agent_folder is defined
         and not checkmk_agent_host_specific | bool
       retries: 3
+      # This task may fail, as we fall back to the generic agent in that case
       failed_when: 'false'
       changed_when: __checkmk_agent_folder_download_state.status is defined and __checkmk_agent_folder_download_state.status == 200
       delegate_to: "{{ checkmk_agent_delegate_download }}"

--- a/roles/agent/tasks/Win32NT.yml
+++ b/roles/agent/tasks/Win32NT.yml
@@ -17,9 +17,6 @@
     state: "present"
   become: false
   register: __checkmk_agent_create_result
-  failed_when: |
-    (__checkmk_agent_create_result.failed == true) and
-    ("The host is already part of the specified target folder" not in __checkmk_agent_create_result.msg)
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   when: checkmk_agent_add_host | bool
   notify: "Activate changes"
@@ -36,9 +33,6 @@
     state: "present"
   become: false
   register: __checkmk_agent_create_result
-  failed_when: |
-    (__checkmk_agent_create_result.failed == true) and
-    ("The host is already part of the specified target folder" not in __checkmk_agent_create_result.msg)
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   when: checkmk_agent_add_host | bool
   notify: "Activate changes"


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a `failed_when` statement on a few tasks which was a workaround back in the day.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The workaround is cleaned up, test indicate, that everything is healthy and the workaround is no longer necessary.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
