### PR TITLE
downtime module: Docs typo, duration is minutes

### DIFF
--- a/plugins/modules/downtime.py
+++ b/plugins/modules/downtime.py
@@ -32,7 +32,7 @@ options:
         default: Created by Ansible
     duration:
         description:
-            - Duration in seconds. When set, the downtime does not begin automatically at a nominated time,
+            - Duration in minutes. When set, the downtime does not begin automatically at a nominated time,
               but when a non-OK status actually appears for the host.
               Consequently, the start_time and end_time is only the time window in which the scheduled downtime can occur.
         type: int


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

----

Tiny docs fix.

Duration is (seemingly) expected by the API to be minutes, not seconds.

Internally, it's already converted to seconds before being passed to the core.

See:
- https://github.com/Checkmk/checkmk/blob/66ce0936da114062aba8a57d4605fea488280989/cmk/gui/livestatus_utils/commands/downtimes.py#L839
- https://github.com/Checkmk/checkmk/blob/66ce0936da114062aba8a57d4605fea488280989/cmk/gui/livestatus_utils/commands/downtimes.py#L852
