### PR TITLE
HTTP Proxy configuration for download of Checkmk Server Setup & GPG Key

### DIFF
--- a/changelogs/fragments/http_proxy.yml
+++ b/changelogs/fragments/http_proxy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - server role - Add support for optional use of a HTTP proxy for downloading the Checkmk Server Setup and GPG Key.

--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -136,6 +136,16 @@ Extension packages can also be listed to be installed on the specific central si
 
 **Attention!** If you are connecting to the remote host via an unprivileged user, you will run into permission issues explained [here](https://docs.ansible.com/ansible-core/2.18/playbook_guide/playbooks_privilege_escalation.html#risks-of-becoming-an-unprivileged-user). The easiest fix will probably be to install your distribution's `acl` package. But the right solution for your environment is entirely up to you.
 
+#### HTTP Proxy
+
+    checkmk_server_download_proxy: []
+
+The HTTP proxy used for downloading the Checkmk Server Setup.
+
+    checkmk_server_gpg_download_proxy: "{{ checkmk_server_download_proxy }}"
+
+The HTTP proxy used for downloading the Checkmk GPG Key.
+
 ### Site Updates
 
     checkmk_server_backup_on_update: true

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -75,3 +75,7 @@ checkmk_server_backup_on_update: true  # Not recommended to disable this option
 checkmk_server_backup_dir: '/tmp'
 checkmk_server_backup_opts: '--no-past'
 checkmk_server_allow_downgrades: 'false'
+
+## HTTP Proxy
+checkmk_server_download_proxy: []
+checkmk_server_gpg_download_proxy: "{{ checkmk_server_download_proxy }}"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -63,6 +63,9 @@
         mode: "0640"
         url_username: "{{ checkmk_server_download_user | default(omit) }}"
         url_password: "{{ checkmk_server_download_pass | default(omit) }}"
+      environment:
+        http_proxy: "{{ checkmk_server_download_proxy | default(omit, true) }}"
+        https_proxy: "{{ checkmk_server_download_proxy | default(omit, true) }}"
       retries: 3
       tags:
         - download-package
@@ -74,6 +77,9 @@
         mode: "0640"
         url_username: "{{ checkmk_server_gpg_download_user | default(omit) }}"
         url_password: "{{ checkmk_server_gpg_download_pass | default(omit) }}"
+      environment:
+        http_proxy: "{{ checkmk_server_gpg_download_proxy | default(omit, true) }}"
+        https_proxy: "{{ checkmk_server_gpg_download_proxy | default(omit, true) }}"
       when: checkmk_server_verify_setup | bool
       retries: 3
       tags:


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently there is no option to specify a HTTP proxy for download the Checkmk Server Setup & GPG Key.

It is possible to specify the necessary environment variables that the play or role level, but this does not work if the remote nodes apt uses a network-local repository. In this the environment variables would overwrite apt's configuration forcing it to use the proxy. This results in a failure on the 'Update APT Cache.' task.

## What is the new behavior?

Now there are new optional variables that allow the specification of http_proxy, https_proxy for downloading the Checkmk Server Setup & GPG Key. Both cases can be separtely configured if needed.