### PR TITLE
Fix site idempotency

### DIFF
--- a/plugins/module_utils/site.py
+++ b/plugins/module_utils/site.py
@@ -111,8 +111,7 @@ class SiteConnection:
         # Before werk 18286, 'secret' was there, after werk 18907, there's 'logged_in'.
         # Between those two werks, login/logout is not possible with this module.
         if self.site_config and (
-            self.site_config.get("secret")
-            or self.site_config.get("logged_in")
+            self.site_config.get("secret") or self.site_config.get("logged_in")
         ):
             return True
 

--- a/plugins/modules/site.py
+++ b/plugins/modules/site.py
@@ -390,7 +390,7 @@ def run_module():
     else:
         exit_module(
             module,
-            msg="Unexpected target state %s" % desired_site_connection.state,
+            msg="Unexpected target state %s." % desired_site_connection.state,
             failed=True,
             logger=logger,
         )


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Werk 18286 breaks idempotency of site module (see Issue Number: #899)
Affected versions: >=2.3.0p37 and >=2.4.0p11

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The site module is idempotent again.
- Prerequisite: Werk 18907 has to be applied to the site (>=2.3.0p40, >=2.4.0p16, >=2.5.0)
- **That means**: For versions _between_ the two werks, the site module doesn't provide idempotency, when it comes to login/logout.
