### PR TITLE
Bugfix download proxy implementation

### DIFF
--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -138,7 +138,7 @@ Extension packages can also be listed to be installed on the specific central si
 
 #### HTTP Proxy
 
-    checkmk_server_download_proxy: []
+    checkmk_server_download_proxy: ''
 
 The HTTP proxy used for downloading the Checkmk Server Setup.
 

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -77,5 +77,5 @@ checkmk_server_backup_opts: '--no-past'
 checkmk_server_allow_downgrades: 'false'
 
 ## HTTP Proxy
-checkmk_server_download_proxy: []
+checkmk_server_download_proxy: ''
 checkmk_server_gpg_download_proxy: "{{ checkmk_server_download_proxy }}"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -22,6 +22,13 @@
     - install-package
     - update-sites
 
+- name: "{{ ansible_system }}: Set Proxy Environment."
+  when: checkmk_server_download_proxy | length > 0
+  ansible.builtin.set_fact:
+    __proxy_env:
+      http_proxy: "{{ checkmk_server_download_proxy | default(omit) }}"
+      https_proxy: "{{ checkmk_server_download_proxy | default(omit) }}"
+
 - name: "{{ ansible_system }}: Get RPM or APT package facts."
   ansible.builtin.package_facts:
     manager: "auto"
@@ -57,45 +64,16 @@
   block:
 
     - name: "{{ ansible_system }}: Download Checkmk Server Setup."
-      when: checkmk_server_download_proxy is defined and checkmk_server_download_proxy | length | bool
       ansible.builtin.get_url:
         url: "{{ checkmk_server_download_url }}"
         dest: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
         mode: "0640"
         url_username: "{{ checkmk_server_download_user | default(omit) }}"
         url_password: "{{ checkmk_server_download_pass | default(omit) }}"
-      environment:
-        http_proxy: "{{ checkmk_server_download_proxy | default(omit) }}"
-        https_proxy: "{{ checkmk_server_download_proxy | default(omit) }}"
+      environment: "{{ __proxy_env | default(omit) }}"
       retries: 3
       tags:
         - download-package
-
-    - name: "{{ ansible_system }}: Download Checkmk Server Setup."
-      ansible.builtin.get_url:
-        url: "{{ checkmk_server_download_url }}"
-        dest: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
-        mode: "0640"
-        url_username: "{{ checkmk_server_download_user | default(omit) }}"
-        url_password: "{{ checkmk_server_download_pass | default(omit) }}"
-      retries: 3
-      tags:
-        - download-package
-
-    - name: "{{ ansible_system }}: Download Checkmk GPG Key."
-      when: checkmk_server_verify_setup | bool and (checkmk_server_download_proxy is defined and checkmk_server_download_proxy | length | bool)
-      ansible.builtin.get_url:
-        url: "{{ checkmk_server_gpg_download_url }}"
-        dest: "{{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
-        mode: "0640"
-        url_username: "{{ checkmk_server_gpg_download_user | default(omit) }}"
-        url_password: "{{ checkmk_server_gpg_download_pass | default(omit) }}"
-      environment:
-        http_proxy: "{{ checkmk_server_gpg_download_proxy | default(omit) }}"
-        https_proxy: "{{ checkmk_server_gpg_download_proxy | default(omit) }}"
-      retries: 3
-      tags:
-        - download-gpg-key
 
     - name: "{{ ansible_system }}: Download Checkmk GPG Key."
       when: checkmk_server_verify_setup | bool
@@ -105,6 +83,7 @@
         mode: "0640"
         url_username: "{{ checkmk_server_gpg_download_user | default(omit) }}"
         url_password: "{{ checkmk_server_gpg_download_pass | default(omit) }}"
+      environment: "{{ __proxy_env | default(omit) }}"
       retries: 3
       tags:
         - download-gpg-key


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->

<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In #906 @phiv0 added support for download proxies for the setup file and the GPG key.
While the featured worked as intended until Ansible 2.18, it broke with 2.19.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR changes the approach #906 took, by concatenating all proxy variables into a `__proxy_env` during role execution, which can then be omitted if empty. This works around the issue with Ansible 2.19, where all means of omitting an empty variable caused weird side effects.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->