### PR TITLE
Bump ansible-core version

### DIFF
--- a/.github/workflows/ans-int-test-activation.yaml
+++ b/.github/workflows/ans-int-test-activation.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-bakery.yaml
+++ b/.github/workflows/ans-int-test-bakery.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-contact_group.yaml
+++ b/.github/workflows/ans-int-test-contact_group.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-dcd.yaml
+++ b/.github/workflows/ans-int-test-dcd.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-discovery.yaml
+++ b/.github/workflows/ans-int-test-discovery.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-downtime.yaml
+++ b/.github/workflows/ans-int-test-downtime.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-folder.yaml
+++ b/.github/workflows/ans-int-test-folder.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-host.yaml
+++ b/.github/workflows/ans-int-test-host.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-host_group.yaml
+++ b/.github/workflows/ans-int-test-host_group.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-bakery.yaml
+++ b/.github/workflows/ans-int-test-lkp-bakery.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-folder.yaml
+++ b/.github/workflows/ans-int-test-lkp-folder.yaml
@@ -39,16 +39,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-folders.yaml
+++ b/.github/workflows/ans-int-test-lkp-folders.yaml
@@ -39,16 +39,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-host.yaml
+++ b/.github/workflows/ans-int-test-lkp-host.yaml
@@ -39,16 +39,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-hosts.yaml
+++ b/.github/workflows/ans-int-test-lkp-hosts.yaml
@@ -39,16 +39,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-rules.yaml
+++ b/.github/workflows/ans-int-test-lkp-rules.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-rulesets.yaml
+++ b/.github/workflows/ans-int-test-lkp-rulesets.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-site.yaml
+++ b/.github/workflows/ans-int-test-lkp-site.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-sites.yaml
+++ b/.github/workflows/ans-int-test-lkp-sites.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-lkp-version.yaml
+++ b/.github/workflows/ans-int-test-lkp-version.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-password.yaml
+++ b/.github/workflows/ans-int-test-password.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-rule.yaml
+++ b/.github/workflows/ans-int-test-rule.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-service_group.yaml
+++ b/.github/workflows/ans-int-test-service_group.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-site.yaml
+++ b/.github/workflows/ans-int-test-site.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-tag_group.yaml
+++ b/.github/workflows/ans-int-test-tag_group.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-timeperiod.yaml
+++ b/.github/workflows/ans-int-test-timeperiod.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-int-test-user.yaml
+++ b/.github/workflows/ans-int-test-user.yaml
@@ -41,16 +41,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     services:

--- a/.github/workflows/ans-unit-test-inventory.yaml
+++ b/.github/workflows/ans-unit-test-inventory.yaml
@@ -36,16 +36,19 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
         python:
           - '3.11'
           - '3.12'
+          - '3.13'
         exclude:
           # Exclude unsupported sets.
           - ansible: devel
+            python: '3.11'
+          - ansible: stable-2.20
             python: '3.11'
 
     steps:

--- a/.github/workflows/ansible-sanity-tests.yaml
+++ b/.github/workflows/ansible-sanity-tests.yaml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
+          - stable-2.20
           - devel
 
     steps:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.17.0'
+requires_ansible: '>=2.18.0'
 
 action_groups:
   checkmk:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "checkmk_ansible_collection"
 version = "6.4.0"
 requires-python = ">=3.11"
 dependencies = [
-    "ansible-core==2.19.4",
     "antsibull-changelog==0.34.0",
     "antsibull-docs==2.23.0",
     "ansible-lint==25.11.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -71,7 +71,7 @@ find "${collection_dir}/roles/" -type f -name README.md -exec sed -i "s/2.4.0.*/
 # Playbooks:
 sed -i "s/2.4.0.*/${checkmk_stable}\"/g" "${collection_dir}/playbooks/vars/auth.yml" && echo "Updated default Checkmk version for playbooks to ${checkmk_stable}."
 # Support Matrix
-grep "${target_version}" "${collection_dir}/SUPPORT.md" > /dev/null || echo "${target_version} | ${checkmk_ancient}, ${checkmk_oldstable}, ${checkmk_stable} | 2.17, 2.18, 2.19 | None" >> "${collection_dir}/SUPPORT.md" && echo "Added line to compatibility matrix in SUPPORT.md."
+grep "${target_version}" "${collection_dir}/SUPPORT.md" > /dev/null || echo "${target_version} | ${checkmk_ancient}, ${checkmk_oldstable}, ${checkmk_stable} | 2.18, 2.19, 2.20 | None" >> "${collection_dir}/SUPPORT.md" && echo "Added line to compatibility matrix in SUPPORT.md."
 # pyproject.toml
 sed -i "s/version = \"${source_version}\"/version = \"${target_version}\"/g" "${collection_dir}/pyproject.toml" && echo "Updated Checkmk version in pyproject.toml from ${source_version} to ${target_version}."
 echo "# End changes section."


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->
This PR bumps the `ansible-core` versions.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are testing against a EOL version of `ansible-core`. while a publicly released one is not explicitely tested.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- EOL `ansible-core` is dropped from testing.
- In turn, the minimum required `ansible-core` version to run this collection was bumped to `2.18`. This is still not a hard technical requirement, older versions will still probably work, we just do not test them anymore.
- Stable `ansible-core` `2.20` is added to the testing matrix.
- `ansible-core` is removed from `pyproject.toml`, to unblock testing and as it never made sense there in the first place.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
ToDo: Check open PRs, so they are in line with these changes!
* #869 
* #922 