### PR TITLE
Fix #917 (adding a site_connection fails)

### DIFF
--- a/plugins/modules/site.py
+++ b/plugins/modules/site.py
@@ -329,7 +329,11 @@ def run_module():
     existing_site_connection = SiteConnection.from_api(site_api.get(site_id))
 
     # Can be removed, once we no longer support Checkmk versions older than 2.3.0p25
-    if site_api.getversion() > CheckmkVersion("2.3.0p25") and not replication_enabled:
+    if (
+        existing_site_connection
+        and site_api.getversion() > CheckmkVersion("2.3.0p25")
+        and not replication_enabled
+    ):
         # Remove unneeded parameters from the existing site connection's config
         logger.debug("Cleaning parameters of existing connection")
         werk16722(existing_site_connection.site_config)


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes as a title in the textbox above -->
Adding a site connection no longer fails when no replication is enabled
<!---
Please use the devel branch as the merge target (see dropdown above)!
We use that branch as a staging area, to make sure the main branch
stays as stable as possible, in case people are using it to install the collection directly.
 -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

#917

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- It's now possible to add a non-replication site.

## Other information
<!-- Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change. -->
