### PR TITLE
Add initial support for Suse derivatives

### DIFF
--- a/changelogs/fragments/suse.yml
+++ b/changelogs/fragments/suse.yml
@@ -1,0 +1,10 @@
+major_changes:
+  - Server role - Introduce initial support for Suse derivatives.
+    Observe the "Known Issues", as this support is experimental!
+
+known_issues:
+  - Server role - Suse support is currently tested only on openSUSE Leap 15. This means, that it is not tested on actual SLES.
+    If you have any interest in this functionality and have a SLES 15 handy, we are happy to collaborate on this.
+  - Server role - SLES has dependencies, which cannot be managed by this role. Refer to the role README for details.
+  - Server role - Suse support does not yet cover the new version scheme starting with SLES 16.
+    As soon as Checkmk supports SLES 16, we will look into updating the role accordingly.

--- a/roles/agent/molecule/2.4.0/converge.yml
+++ b/roles/agent/molecule/2.4.0/converge.yml
@@ -42,6 +42,15 @@
       ansible.builtin.command: chmod 0400 /etc/shadow
       when: ansible_facts['distribution'] == 'Rocky' and (ansible_facts['distribution_major_version'] == '9' or ansible_facts['distribution_major_version'] == '10')
 
+    # This seems Suse specific: https://support.scc.suse.com/s/kb/Ansible-fails-to-run-ansible-builtin-package-facts?language=en_US
+    - name: "Install prerequisites."
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - python311-rpm  # Actual dependency, needed before first role run
+      when: ansible_facts['os_family'] == 'Suse'
+
   tasks:
 
     - name: "Run server role."

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -58,6 +58,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns: host
     systemd: always
+  - name: opensuse15
+    image: docker.io/geerlingguy/docker-opensuseleap15-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
+    systemd: always
 provisioner:
   name: ansible
   connection_options:

--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -13,6 +13,12 @@ It can be installed as easy as running:
 
 Refer to [INSTALL.md](../../INSTALL.md) for detailed installation instructions.
 
+### A note about SLES
+SLES has some special dependencies, which cannot be managed by this role
+directly. You can automate them yourself, but this role assumes,
+that the modules mentioned in [Section 1 of the official guide](https://docs.checkmk.com/latest/en/install_packages_sles.html)
+are already present on your system.
+
 ## Distribution support
 
 This role includes explicit distribution support.

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -21,12 +21,14 @@ checkmk_server_server_stable_os:
   - RedHat-8
   - RedHat-9
   - RedHat-10
+  - openSUSE Leap-15
   - OracleLinux-8
   - OracleLinux-9
   - OracleLinux-10
   - Rocky-8
   - Rocky-9
   - Rocky-10
+  - SLES-15
   - Ubuntu-18
   - Ubuntu-20
   - Ubuntu-22

--- a/roles/server/molecule/2.4.0/converge.yml
+++ b/roles/server/molecule/2.4.0/converge.yml
@@ -33,6 +33,15 @@
       ansible.builtin.command: chmod 0400 /etc/shadow
       when: ansible_facts['distribution'] == 'Rocky' and (ansible_facts['distribution_major_version'] == '9' or ansible_facts['distribution_major_version'] == '10')
 
+    # This seems Suse specific: https://support.scc.suse.com/s/kb/Ansible-fails-to-run-ansible-builtin-package-facts?language=en_US
+    - name: "Install prerequisites."
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - python311-rpm  # Actual dependency, needed before first role run
+      when: ansible_facts['os_family'] == 'Suse'
+
     - name: "Download MKP."
       ansible.builtin.get_url:
         url: https://exchange.checkmk.com/packages/sslcertificates/1928/sslcertificates-9.2.1.mkp

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -67,6 +67,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns: host
     systemd: always
+  - name: opensuse15
+    image: docker.io/geerlingguy/docker-opensuseleap15-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
+    systemd: always
 provisioner:
   name: ansible
   connection_options:

--- a/roles/server/tasks/Suse.yml
+++ b/roles/server/tasks/Suse.yml
@@ -1,0 +1,41 @@
+---
+- name: "{{ ansible_facts['os_family'] }} Derivatives: Install Checkmk Server."
+  when: not 'check-mk-' + __checkmk_server_edition_mapping[checkmk_server_edition] + '-' +checkmk_server_version in ansible_facts['packages']
+  become: true
+  community.general.zypper:
+    name: "{{ __checkmk_server_tmp_dir }}/{{ __checkmk_server_setup_file }}"
+    state: present
+    disable_gpg_check: "{{ not checkmk_server_verify_setup | bool }}"
+    force_resolution: true
+    simple_errors: true
+  notify: Start httpd
+  tags:
+    - install-package
+
+- name: "{{ ansible_facts['os_family'] }} Derivatives: Enable httpd can network connect selinux boolean."
+  become: true
+  ansible.posix.seboolean:
+    name: httpd_can_network_connect
+    state: true
+    persistent: true
+  when: ansible_facts['selinux']['status'] == 'enabled'
+  tags:
+    - set-selinux-boolean
+
+- name: "{{ ansible_facts['os_family'] }} Derivatives: Make sure firewalld is started and enabled."
+  become: true
+  ansible.builtin.systemd:
+    name: firewalld
+    state: started
+    enabled: true
+  when: checkmk_server_configure_firewall | bool
+
+- name: "{{ ansible_facts['os_family'] }} Derivatives: Open Firewall Ports for the Checkmk Server."
+  when: checkmk_server_configure_firewall | bool and "firewalld.service" in ansible_facts['services']
+  ansible.posix.firewalld:
+    permanent: true
+    immediate: "{% if ansible_facts['services']['firewalld.service']['state'] == 'running' %}true{% else %}false{% endif %}"
+    port: "{{ item }}/tcp"
+    state: "enabled"
+  become: true
+  loop: "{{ checkmk_server_ports }}"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -132,7 +132,7 @@
       ansible.builtin.rpm_key:
         key: "{{ __checkmk_server_tmp_dir }}/Check_MK-pubkey.gpg"
         state: present
-      when: checkmk_server_verify_setup | bool and ansible_facts['os_family'] == "RedHat"
+      when: checkmk_server_verify_setup | bool and not ansible_facts['os_family'] == "Debian"
       tags:
         - import-gpg-key
 

--- a/roles/server/vars/Suse.yml
+++ b/roles/server/vars/Suse.yml
@@ -1,0 +1,18 @@
+---
+# The versioning scheme changes with SLES 16. We will look into this, once Checkmk supports SLES 16.
+# https://documentation.suse.com/sles/16.0/html/SLE-comparison/index.html#sle16-versioning
+__checkmk_server_setup_file: |-
+  check-mk-{{ __checkmk_server_edition_mapping[checkmk_server_edition | lower] }}-{{ checkmk_server_version }}-sles{{ ansible_facts['distribution_major_version'] }}sp{{ ansible_facts['distribution_release'] }}-38.x86_64.rpm
+
+__checkmk_server_prerequisites_per_distro:
+  SLES-15:
+    - firewalld
+    - python311-firewall
+    - python311-rpm
+  openSUSE Leap-15:
+    - firewalld
+    - python311-firewall
+    - python311-rpm
+
+__checkmk_server_prerequisites: "{{ __checkmk_server_prerequisites_per_distro[ansible_facts['distribution'] ~ '-' ~ ansible_facts['distribution_major_version']]
+  | default( __checkmk_server_prerequisites_per_distro[ ansible_facts['distribution_file_variety'] ]) }}"


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

No SUSE derivatives are supported by the `server` role as of now.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

This is a first implementation of support for SUSE derivatives based on openSUSE Leap 15.
**Be advised, that this support is experimental on a best effort basis and has limitations.**
See the role README for details.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.

We would love to collaborate with you to push this across the finish line!
If you are savvy with openSUSE or SLES, or if you actually run any of these distributions at home or in production, please do reach out. We are eager to get this finalized.