### PR TITLE
Simplify integration tests for lookup plugins

### DIFF
--- a/.github/labels-issues.yml
+++ b/.github/labels-issues.yml
@@ -70,38 +70,26 @@ lookup:bakery:
 
 lookup:folder:
   - 'Component Name: lookup_folder'
-
-lookup:folders:
   - 'Component Name: lookup_folders'
 
 lookup:host:
   - 'Component Name: lookup_host'
-
-lookup:hosts:
   - 'Component Name: lookup_hosts'
 
 lookup:ldap_connection:
   - 'Component Name: lookup_ldap_connection'
-
-lookup:ldap_connections:
   - 'Component Name: lookup_ldap_connections'
 
 lookup:rule:
   - 'Component Name: lookup_rule'
-
-lookup:rules:
   - 'Component Name: lookup_rules'
 
 lookup:ruleset:
   - 'Component Name: lookup_ruleset'
-
-lookup:rulesets:
   - 'Component Name: lookup_rulesets'
 
 lookup:site:
   - 'Component Name: lookup_site'
-
-lookup:sites:
   - 'Component Name: lookup_sites'
 
 lookup:version:

--- a/.github/labels-prs.yml
+++ b/.github/labels-prs.yml
@@ -113,60 +113,36 @@ lookup:folder:
   - any:
       - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/folder.py'
-
-lookup:folders:
-  - any:
-      - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/folders.py'
 
 lookup:host:
   - any:
       - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/host.py'
-
-lookup:hosts:
-  - any:
-      - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/hosts.py'
 
 lookup:ldap_connection:
   - any:
       - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/ldap_connection.py'
-
-lookup:ldap_connections:
-  - any:
-      - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/ldap_connections.py'
 
 lookup:rule:
   - any:
       - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/rule.py'
-
-lookup:rules:
-  - any:
-      - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/rules.py'
 
 lookup:ruleset:
   - any:
       - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/ruleset.py'
-
-lookup:rulesets:
-  - any:
-      - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/rulesets.py'
 
 lookup:site:
   - any:
       - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/site.py'
-
-lookup:sites:
-  - any:
-      - changed-files:
           - any-glob-to-any-file: 'plugins/modules/lookup/sites.py'
 
 lookup:version:

--- a/.github/workflows/ans-int-test-lkp-folder.yaml
+++ b/.github/workflows/ans-int-test-lkp-folder.yaml
@@ -13,10 +13,12 @@ on:
       - devel
     paths:
       - 'plugins/lookup/folder.py'
+      - 'plugins/lookup/folders.py'
   push:
     paths:
       - '.github/workflows/ans-int-test-lkp-folder.yaml'
       - 'plugins/lookup/folder.py'
+      - 'plugins/lookup/folders.py'
       - 'plugins/module_utils/**'
       - 'tests/integration/files/includes/**'
       - 'tests/integration/targets/lookup_folder/**'

--- a/.github/workflows/ans-int-test-lkp-host.yaml
+++ b/.github/workflows/ans-int-test-lkp-host.yaml
@@ -13,10 +13,12 @@ on:
       - devel
     paths:
       - 'plugins/lookup/host.py'
+      - 'plugins/lookup/hosts.py'
   push:
     paths:
       - '.github/workflows/ans-int-test-lkp-host.yaml'
       - 'plugins/lookup/host.py'
+      - 'plugins/lookup/hosts.py'
       - 'plugins/module_utils/**'
       - 'tests/integration/files/includes/**'
       - 'tests/integration/targets/lookup_host/**'

--- a/.github/workflows/ans-int-test-lkp-ldap_connection.yaml
+++ b/.github/workflows/ans-int-test-lkp-ldap_connection.yaml
@@ -13,10 +13,12 @@ on:
       - devel
     paths:
       - 'plugins/lookup/ldap_connection.py'
+      - 'plugins/lookup/ldap_connections.py'
   push:
     paths:
       - '.github/workflows/ans-int-test-lkp-ldap_connection.yaml'
       - 'plugins/lookup/ldap_connection.py'
+      - 'plugins/lookup/ldap_connections.py'
       - 'plugins/module_utils/**'
       - 'tests/integration/files/includes/**'
       - 'tests/integration/targets/lookup_ldap_connection/**'

--- a/.github/workflows/ans-int-test-lkp-site.yaml
+++ b/.github/workflows/ans-int-test-lkp-site.yaml
@@ -13,10 +13,12 @@ on:
       - devel
     paths:
       - 'plugins/lookup/site.py'
+      - 'plugins/lookup/sites.py'
   push:
     paths:
       - '.github/workflows/ans-int-test-lkp-site.yaml'
       - 'plugins/lookup/site.py'
+      - 'plugins/lookup/sites.py'
       - 'plugins/module_utils/**'
       - 'tests/integration/files/includes/**'
       - 'tests/integration/targets/lookup_site/**'

--- a/tests/integration/targets/lookup_folder/tasks/test.yml
+++ b/tests/integration/targets/lookup_folder/tasks/test.yml
@@ -3,77 +3,100 @@
   ansible.builtin.set_fact:
     checkmk_var_customer: "{{ 'provider' if outer_item.edition == 'cme' else None }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create folder."
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create folders."
   folder:
     server_url: "{{ checkmk_var_server_url }}"
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-    name: "{{ checkmk_var_folder.name }}"
-    path: "{{ checkmk_var_folder.path }}"
-    attributes:
-      tag_criticality: "{{ checkmk_var_folder.criticality }}"
+    name: "{{ item.name }}"
+    path: "{{ item.path }}"
+    update_attributes:
+      tag_criticality: "{{ item.criticality }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all folders."
-  ansible.builtin.debug:
-    var: __checkmk_var_folders
-  vars:
-    __checkmk_var_folders: "{{ lookup('checkmk.general.folders',
-                    '/',
-                    server_url=checkmk_var_server_url,
-                    site=outer_item.site,
-                    validate_certs=False,
-                    api_user=checkmk_var_api_user,
-                    api_secret=checkmk_var_api_secret)
-              }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  ansible.builtin.set_fact:
+    __checkmk_var_folder_list: "{{ lookup('checkmk.general.folders', '/',
+                           recursive=True,
+                           server_url=checkmk_var_server_url,
+                           site=outer_item.site,
+                           validate_certs=False,
+                           api_user=checkmk_var_api_user,
+                           api_secret=checkmk_var_api_secret) }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get attributes of folder."
-  ansible.builtin.debug:
-    msg: "Criticality of {{ checkmk_var_folder.name }} is {{ __checkmk_var_folder.extensions.attributes.tag_criticality }}"
-  vars:
-    __checkmk_var_folder: "{{ lookup('checkmk.general.folder',
-                    checkmk_var_folder.path,
-                    server_url=checkmk_var_server_url,
-                    site=outer_item.site,
-                    validate_certs=False,
-                    api_user=checkmk_var_api_user,
-                    api_secret=checkmk_var_api_secret)
-              }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder count."
+  ansible.builtin.assert:
+    that: "__checkmk_var_folder_list | length == (checkmk_var_folders | length + 1)"
+    fail_msg: "Expected {{ checkmk_var_folders | length + 1 }} folders, but found {{ __checkmk_var_folder_list | length }}!"
+    success_msg: "Expected {{ checkmk_var_folders | length + 1 }} folders, and found {{ __checkmk_var_folder_list | length }}."
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder criticality."
   ansible.builtin.assert:
-    that: "__checkmk_var_folder.extensions.attributes.tag_criticality == checkmk_var_folder.criticality"
+    that: "item.extensions.attributes.tag_criticality == (checkmk_var_folders | selectattr('path', 'equalto', item.extensions.path) | map(attribute='criticality') | first)"
+    fail_msg: "Expected {{ item.id }} tag_criticality to be {{ checkmk_var_folders | selectattr('path', 'equalto', item.extensions.path) | map(attribute='criticality') | first }}, but found {{ item.extensions.attributes.tag_criticality }}!"
+    success_msg: "Expected {{ item.id }} tag_criticality to be {{ checkmk_var_folders | selectattr('path', 'equalto', item.extensions.path) | map(attribute='criticality') | first }}, and found {{ item.extensions.attributes.tag_criticality }}."
+  loop: "{{ __checkmk_var_folder_list }}"
+  when: item.id != '~'
+  loop_control:
+    label: "{{ item.id }}"
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder criticality per host."
+  ansible.builtin.assert:
+    that: "__checkmk_var_folder.extensions.attributes.tag_criticality == item.extensions.attributes.tag_criticality"
+    fail_msg: "Expected {{ item.id }} tag_criticality to be {{ item.extensions.attributes.tag_criticality }}, but found {{ __checkmk_var_folder.extensions.attributes.tag_criticality }}!"
+    success_msg: "Expected {{ item.id }} tag_criticality to be {{ item.extensions.attributes.tag_criticality }}, and found {{ __checkmk_var_folder.extensions.attributes.tag_criticality }}."
   vars:
     __checkmk_var_folder: "{{ lookup('checkmk.general.folder',
-                    checkmk_var_folder.path,
+                    item.id,
                     server_url=checkmk_var_server_url,
                     site=outer_item.site,
                     validate_certs=False,
                     api_user=checkmk_var_api_user,
                     api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  loop: "{{ __checkmk_var_folder_list }}"
+  when: item.id != '~'
+  loop_control:
+    label: "{{ item.id }}"
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
     - name: "Set checkmk_var_server_url for isolated testing."
       ansible.builtin.set_fact:
         checkmk_var_server_url: "http://127.0.0.1:5104/"
 
-    - name: "Test plugin with variables from inventory."
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all folders."
+      ansible.builtin.set_fact:
+        __checkmk_var_folder_list: "{{ lookup('checkmk.general.folders', '/', recursive=True) }}"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder count."
       ansible.builtin.assert:
-        that: "__checkmk_var_folder.extensions.attributes.tag_criticality == checkmk_var_folder.criticality"
+        that: "__checkmk_var_folder_list | length == (checkmk_var_folders | length + 1)"
+        fail_msg: "Expected {{ checkmk_var_folders | length + 1 }} folders, but found {{ __checkmk_var_folder_list | length }}!"
+        success_msg: "Expected {{ checkmk_var_folders | length + 1 }} folders, and found {{ __checkmk_var_folder_list | length }}."
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder criticality."
+      ansible.builtin.assert:
+        that: "item.extensions.attributes.tag_criticality == (checkmk_var_folders | selectattr('path', 'equalto', item.extensions.path) | map(attribute='criticality') | first)"
+        fail_msg: "Expected {{ item.id }} tag_criticality to be {{ checkmk_var_folders | selectattr('path', 'equalto', item.extensions.path) | map(attribute='criticality') | first }}, but found {{ item.extensions.attributes.tag_criticality }}!"
+        success_msg: "Expected {{ item.id }} tag_criticality to be {{ checkmk_var_folders | selectattr('path', 'equalto', item.extensions.path) | map(attribute='criticality') | first }}, and found {{ item.extensions.attributes.tag_criticality }}."
+      loop: "{{ __checkmk_var_folder_list }}"
+      when: item.id != '~'
+      loop_control:
+        label: "{{ item.id }}"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify folder criticality per host."
+      ansible.builtin.assert:
+        that: "__checkmk_var_folder.extensions.attributes.tag_criticality == item.extensions.attributes.tag_criticality"
+        fail_msg: "Expected {{ item.id }} tag_criticality to be {{ item.extensions.attributes.tag_criticality }}, but found {{ __checkmk_var_folder.extensions.attributes.tag_criticality }}!"
+        success_msg: "Expected {{ item.id }} tag_criticality to be {{ item.extensions.attributes.tag_criticality }}, and found {{ __checkmk_var_folder.extensions.attributes.tag_criticality }}."
       vars:
-        __checkmk_var_folder: "{{ lookup('checkmk.general.folder', checkmk_var_folder.path) }}"
+        __checkmk_var_folder: "{{ lookup('checkmk.general.folder', item.id) }}"
+      loop: "{{ __checkmk_var_folder_list }}"
+      when: item.id != '~'
+      loop_control:
+        label: "{{ item.id }}"

--- a/tests/integration/targets/lookup_folder/vars/main.yml
+++ b/tests/integration/targets/lookup_folder/vars/main.yml
@@ -17,7 +17,16 @@ checkmk_var_test_sites:
     site: "stable_cme"
     port: "5104"
 
-checkmk_var_folder:
-  name: "Folder 1"
-  path: "/folder1"
-  criticality: "test"
+checkmk_var_folders:
+  - name: "Folder 1"
+    path: "/folder1"
+    criticality: "test"
+  - name: "Folder 2"
+    path: "/folder2"
+    criticality: "test"
+  - name: "Folder 3"
+    path: "/folder3"
+    criticality: "test"
+  - name: "Folder 3a"
+    path: "/folder3/a"
+    criticality: "prod"

--- a/tests/integration/targets/lookup_host/tasks/test.yml
+++ b/tests/integration/targets/lookup_host/tasks/test.yml
@@ -3,64 +3,107 @@
   ansible.builtin.set_fact:
     checkmk_var_customer: "{{ 'provider' if outer_item.edition == 'cme' else None }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create host."
-  host:
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
+  checkmk.general.host:
     server_url: "{{ checkmk_var_server_url }}"
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-    name: "{{ checkmk_var_host.name }}"
-    folder: "{{ checkmk_var_host.folder }}"
+    name: "{{ item.name }}"
+    folder: "{{ item.folder | default('/') }}"
     attributes:
       site: "{{ outer_item.site }}"
-      ipaddress: 127.0.0.1
-      alias: "{{ checkmk_var_host.alias }}"
+      ipaddress: "127.0.0.1"
+      alias: "{{ item.alias }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_var_hosts }}"
 
-- name: "{{ outer_item.host }} - Get attributes of host."
-  ansible.builtin.debug:
-    msg: "Alias of {{ checkmk_var_host.name }} is {{ __checkmk_var_host.attributes.alias }}"
-  vars:
-    __checkmk_var_host: "{{ lookup('checkmk.general.host',
-                    checkmk_var_host.name,
-                    server_url=checkmk_var_server_url,
-                    site=outer_item.site,
-                    validate_certs=False,
-                    api_user=checkmk_var_api_user,
-                    api_secret=checkmk_var_api_secret)
-              }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all hosts."
+  ansible.builtin.set_fact:
+    __checkmk_var_hosts_list: "{{ lookup('checkmk.general.hosts',
+                         server_url=checkmk_var_server_url,
+                         site=outer_item.site,
+                         validate_certs=False,
+                         api_user=checkmk_var_api_user,
+                         api_secret=checkmk_var_api_secret) }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host alias."
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host count."
   ansible.builtin.assert:
-    that: "checkmk_var_host.alias == __checkmk_var_host.attributes.alias"
+    that: "__checkmk_var_hosts_list | length == checkmk_var_hosts | length"
+    fail_msg: "Expected {{ checkmk_var_hosts | length }} hosts, but found {{ __checkmk_var_hosts_list | length }}!"
+    success_msg: "Expected {{ checkmk_var_hosts | length }} hosts, and found {{ __checkmk_var_hosts_list | length }}."
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host aliases."
+  ansible.builtin.assert:
+    that: "item.extensions.attributes.alias == (checkmk_var_hosts | selectattr('name', 'equalto', item.id) | map(attribute='alias') | first)"
+    fail_msg: "Expected {{ item.id }} alias to be {{ checkmk_var_hosts | selectattr('name', 'equalto', item.id) | map(attribute='alias') | first }}, but found {{ item.extensions.attributes.alias }}!"
+    success_msg: "Expected {{ item.id }} alias to be {{ checkmk_var_hosts | selectattr('name', 'equalto', item.id) | map(attribute='alias') | first }}, and found {{ item.extensions.attributes.alias }}."
+  loop: "{{ __checkmk_var_hosts_list }}"
+  loop_control:
+    label: "{{ item.id }}"
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host alias per host."
+  ansible.builtin.assert:
+    that: "item.extensions.attributes.alias == __checkmk_var_host.attributes.alias"
+    fail_msg: "Expected {{ item.id }} alias to be {{ item.extensions.attributes.alias }}, but found {{ __checkmk_var_host.attributes.alias }}!"
+    success_msg: "Expected {{ item.id }} alias to be {{ item.extensions.attributes.alias }}, and found {{ __checkmk_var_host.attributes.alias }}."
   vars:
     __checkmk_var_host: "{{ lookup('checkmk.general.host',
-                    checkmk_var_host.name,
+                    item.id,
                     server_url=checkmk_var_server_url,
                     site=outer_item.site,
                     validate_certs=False,
                     api_user=checkmk_var_api_user,
                     api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  loop: "{{ __checkmk_var_hosts_list }}"
+
+# - name: "{{ outer_item.host }} - {{ outer_item.edition | upper }} - Get aliases of single hosts."
+#   ansible.builtin.debug:
+#     msg: "Alias of {{ item.id }} is {{ __checkmk_var_host.attributes.alias }}"
+#   vars:
+#     __checkmk_var_host: "{{ lookup('checkmk.general.host',
+#                     item.id,
+#                     server_url=checkmk_var_server_url,
+#                     site=outer_item.site,
+#                     validate_certs=False,
+#                     api_user=checkmk_var_api_user,
+#                     api_secret=checkmk_var_api_secret)
+#               }}"
+#   loop: "{{ __checkmk_var_hosts_list }}"
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
-    - name: "Set checkmk_var_server_url for isolated testing."
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Set checkmk_var_server_url for isolated testing."
       ansible.builtin.set_fact:
         checkmk_var_server_url: "http://127.0.0.1:5104/"
 
-    - name: "Test plugin with variables from inventory."
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all hosts."
+      ansible.builtin.set_fact:
+        __checkmk_var_hosts_list: "{{ lookup('checkmk.general.hosts') }}"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host count."
       ansible.builtin.assert:
-        that: "checkmk_var_host.alias == __checkmk_var_host.attributes.alias"
+        that: "__checkmk_var_hosts_list | length == checkmk_var_hosts | length"
+        fail_msg: "Expected {{ checkmk_var_hosts | length }} folders, but found {{ __checkmk_var_hosts_list | length }}!"
+        success_msg: "Expected {{ checkmk_var_hosts | length }} folders, and found {{ __checkmk_var_hosts_list | length }}."
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host aliases."
+      ansible.builtin.assert:
+        that: "item.extensions.attributes.alias == (checkmk_var_hosts | selectattr('name', 'equalto', item.id) | map(attribute='alias') | first)"
+        fail_msg: "Expected {{ item.id }} alias to be {{ checkmk_var_hosts | selectattr('name', 'equalto', item.id) | map(attribute='alias') | first }}, but found {{ item.extensions.attributes.alias }}!"
+        success_msg: "Expected {{ item.id }} alias to be {{ checkmk_var_hosts | selectattr('name', 'equalto', item.id) | map(attribute='alias') | first }}, and found {{ item.extensions.attributes.alias }}."
+      loop: "{{ __checkmk_var_hosts_list }}"
+      loop_control:
+        label: "{{ item.id }}"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host alias per host."
+      ansible.builtin.assert:
+        that: "item.extensions.attributes.alias == __checkmk_var_host.attributes.alias"
+        fail_msg: "Expected {{ item.id }} alias to be {{ item.extensions.attributes.alias }}, but found {{ __checkmk_var_host.attributes.alias }}!"
+        success_msg: "Expected {{ item.id }} alias to be {{ item.extensions.attributes.alias }}, and found {{ __checkmk_var_host.attributes.alias }}."
       vars:
-        __checkmk_var_host: "{{ lookup('checkmk.general.host', checkmk_var_host.name) }}"
+        __checkmk_var_host: "{{ lookup('checkmk.general.host', item.id) }}"
+      loop: "{{ __checkmk_var_hosts_list }}"

--- a/tests/integration/targets/lookup_host/vars/main.yml
+++ b/tests/integration/targets/lookup_host/vars/main.yml
@@ -17,7 +17,13 @@ checkmk_var_test_sites:
     site: "stable_cme"
     port: "5104"
 
-checkmk_var_host:
-  name: "host1.tld"
-  folder: "/"
-  alias: "Host 1"
+checkmk_var_hosts:
+  - name: "host1.tld"
+    folder: "/"
+    alias: "Host 1"
+  - name: "host2.tld"
+    folder: "/"
+    alias: "Host 2"
+  - name: "host3.tld"
+    folder: "/"
+    alias: "Host 3"

--- a/tests/integration/targets/lookup_ldap_connection/tasks/test.yml
+++ b/tests/integration/targets/lookup_ldap_connection/tasks/test.yml
@@ -3,59 +3,74 @@
   ansible.builtin.set_fact:
     checkmk_var_customer: "{{ 'provider' if outer_item.edition == 'cme' else None }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create LDAP connection."
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create LDAP connections."
   ldap:
     server_url: "{{ checkmk_var_server_url }}"
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-    ldap_config: "{{ checkmk_var_ldap_connection.ldap_config }}"
+    ldap_config: "{{ item.ldap_config }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  loop: "{{ checkmk_var_ldap_connections }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} Get attributes of LDAP connection."
-  ansible.builtin.debug:
-    msg: "Description of {{ checkmk_var_ldap_connection.ldap_config.general_properties.id }} is {{ __checkmk_var_ldap_connection.general_properties.description }}"
-  vars:
-    __checkmk_var_ldap_connection: "{{ lookup('checkmk.general.ldap_connection',
-                    checkmk_var_ldap_connection.ldap_config.general_properties.id,
-                    server_url=checkmk_var_server_url,
-                    site=outer_item.site,
-                    validate_certs=False,
-                    api_user=checkmk_var_api_user,
-                    api_secret=checkmk_var_api_secret)
-              }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all LDAP connections."
+  ansible.builtin.set_fact:
+    __checkmk_var_ldap_connections: "{{ lookup('checkmk.general.ldap_connections',
+                         server_url=checkmk_var_server_url,
+                         site=outer_item.site,
+                         validate_certs=False,
+                         api_user=checkmk_var_api_user,
+                         api_secret=checkmk_var_api_secret) }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify LDAP connection description."
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify number of LDAP connections."
   ansible.builtin.assert:
-    that: "checkmk_var_ldap_connection.ldap_config.general_properties.description == __checkmk_var_ldap_connection.general_properties.description"
+    that: "checkmk_var_ldap_connections | length == __checkmk_var_ldap_connections | length"
+    fail_msg: "Expected {{ checkmk_var_ldap_connections | length }} connections, but found {{ __checkmk_var_ldap_connections | length }}!"
+    success_msg: "Expected {{ checkmk_var_ldap_connections | length }} connections, and found {{ __checkmk_var_ldap_connections | length }}."
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify LDAP connection descriptions."
+  ansible.builtin.assert:
+    that: "__checkmk_var_ldap_connection.general_properties.description == (checkmk_var_ldap_connections | selectattr('ldap_config.general_properties.id', 'equalto', item.id) | map(attribute='ldap_config.general_properties.description') | first)"
+    fail_msg: "Expected {{ item.id }} description to be {{ checkmk_var_ldap_connections | selectattr('ldap_config.general_properties.id', 'equalto', item.id) | map(attribute='ldap_config.general_properties.description') | first }}, but found {{ __checkmk_var_ldap_connection.general_properties.description }}!"
+    success_msg: "Expected {{ item.id }} description to be {{ checkmk_var_ldap_connections | selectattr('ldap_config.general_properties.id', 'equalto', item.id) | map(attribute='ldap_config.general_properties.description') | first }}, and found {{ __checkmk_var_ldap_connection.general_properties.description }}."
   vars:
     __checkmk_var_ldap_connection: "{{ lookup('checkmk.general.ldap_connection',
-                    checkmk_var_ldap_connection.ldap_config.general_properties.id,
+                    item.id,
                     server_url=checkmk_var_server_url,
                     site=outer_item.site,
                     validate_certs=False,
                     api_user=checkmk_var_api_user,
                     api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+  loop: "{{ __checkmk_var_ldap_connections }}"
+  loop_control:
+    label: "{{ item.id }}"
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
-    - name: "Set checkmk_var_server_url for isolated testing."
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Set checkmk_var_server_url for isolated testing."
       ansible.builtin.set_fact:
         checkmk_var_server_url: "http://127.0.0.1:5104/"
 
-    - name: "Test plugin with variables from inventory."
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all LDAP connections."
+      ansible.builtin.set_fact:
+        __checkmk_var_ldap_connections: "{{ lookup('checkmk.general.ldap_connections') }}"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify number of LDAP connections."
       ansible.builtin.assert:
-        that: "checkmk_var_ldap_connection.ldap_config.general_properties.description == __checkmk_var_ldap_connection.general_properties.description"
+        that: "checkmk_var_ldap_connections | length == __checkmk_var_ldap_connections | length"
+        fail_msg: "Expected {{ checkmk_var_ldap_connections | length }} connections, but found {{ __checkmk_var_ldap_connections | length }}!"
+        success_msg: "Expected {{ checkmk_var_ldap_connections | length }} connections, and found {{ __checkmk_var_ldap_connections | length }}."
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify LDAP connection descriptions."
+      ansible.builtin.assert:
+        that: "__checkmk_var_ldap_connection.general_properties.description == (checkmk_var_ldap_connections | selectattr('ldap_config.general_properties.id', 'equalto', item.id) | map(attribute='ldap_config.general_properties.description') | first)"
+        fail_msg: "Expected {{ item.id }} description to be {{ checkmk_var_ldap_connections | selectattr('ldap_config.general_properties.id', 'equalto', item.id) | map(attribute='ldap_config.general_properties.description') | first }}, but found {{ __checkmk_var_ldap_connection.general_properties.description }}!"
+        success_msg: "Expected {{ item.id }} description to be {{ checkmk_var_ldap_connections | selectattr('ldap_config.general_properties.id', 'equalto', item.id) | map(attribute='ldap_config.general_properties.description') | first }}, and found {{ __checkmk_var_ldap_connection.general_properties.description }}."
       vars:
-        __checkmk_var_ldap_connection: "{{ lookup('checkmk.general.ldap_connection', checkmk_var_ldap_connection.ldap_config.general_properties.id) }}"
+        __checkmk_var_ldap_connection: "{{ lookup('checkmk.general.ldap_connection', item.id) }}"
+      loop: "{{ __checkmk_var_ldap_connections }}"
+      loop_control:
+        label: "{{ item.id }}"

--- a/tests/integration/targets/lookup_ldap_connection/vars/main.yml
+++ b/tests/integration/targets/lookup_ldap_connection/vars/main.yml
@@ -9,15 +9,76 @@ checkmk_var_test_sites:
     site: "stable_cme"
     port: "5104"
 
-checkmk_var_ldap_connection:
-  ldap_config:
-    general_properties:
-      id: "test_ldap_defaults"
-      rule_activation: activated
-      comment: "defaults"
-      description: "ois easy"
-      documentation_url: "www.checkmk.com"
-    ldap_connection:
-      directory_type:
-        type: "open_ldap"
-        ldap_server: "my.ldap.server.tld"
+checkmk_var_ldap_connections:
+  - ldap_config:
+      general_properties:
+        id: "test_ldap_defaults"
+        rule_activation: activated
+        comment: "defaults"
+        description: "ois easy"
+        documentation_url: "www.checkmk.com"
+      ldap_connection:
+        directory_type:
+          type: "open_ldap"
+          ldap_server: "my.ldap.server.tld"
+  - ldap_config:
+      general_properties:
+        id: "test_ldap_complex"
+        rule_activation: activated
+        comment: "komplex"
+        description: "echt kompliziert"
+        documentation_url: "www.checkmk.com"
+      ldap_connection:
+        directory_type:
+          type: "open_ldap"
+          ldap_server: "my.ldap.server.tld"
+          failover_servers:
+            - my2nd.ldap.server.tld
+            - my3rd.ldap.server.tld
+        bind_credentials:
+          bind_dn: "ldap-ro"
+          type: store
+          password_store_id: "ldap_ro"
+        ssl_encryption: enable_ssl
+        tcp_port: 1234
+        connect_timeout: 3
+        ldap_version: 2
+        page_size: 2000
+        response_timeout: 8
+        connection_suffix: "dc=domaincomp,dc=de"
+      users:
+        user_base_dn: "basen.und.vettern"
+        search_scope: search_only_base_dn_entry
+        search_filter: "(abc=123)"
+        filter_group: "(member=xyz)"
+        user_id_attribute: samaccountname
+        user_id_case: convert_to_lowercase
+        umlauts_in_user_ids: replace_umlauts
+        create_users: on_sync
+      groups:
+        group_base_dn: "basen.und.vettern"
+        search_scope: search_only_base_dn_entry
+        search_filter: "(abc=123)"
+        member_attribute: "momper"
+      sync_plugins:
+        alias: blubb
+        visibility_of_hosts_or_services: blobb
+        contact_group_membership:
+          handle_nested: true
+          sync_from_other_connections: test_ldap_defaults
+        groups_to_custom_user_attributes:
+          handle_nested: true
+          groups_to_sync:
+            - group_cn: "cn=blibb,ou=basen.und.vettern"
+              attribute_to_set: mega_menu_icons
+              value: per_entry
+            - group_cn: "cn=blabb,ou=basen.und.vettern"
+              attribute_to_set: mega_menu_icons
+              value: per_entry
+        groups_to_roles:
+          handle_nested: true
+          roles_to_sync:
+            - role: admin
+              groups:
+                - group_dn: "cn=bleb,ou=basen.und.vettern"
+                  search_in: this_connection

--- a/tests/integration/targets/lookup_site/tasks/test.yml
+++ b/tests/integration/targets/lookup_site/tasks/test.yml
@@ -1,46 +1,77 @@
 ---
-- name: " {{ outer_item.version }} - {{ outer_item.edition | upper }} - Get config of the site."
-  ansible.builtin.debug:
-    msg: "Config of site {{ __checkmk_var_site.basic_settings.site_id }}: {{ __checkmk_var_site }}"
-  vars:
-    __checkmk_var_site: "{{ lookup('checkmk.general.site',
-                    outer_item.site,
-                    server_url=checkmk_var_server_url,
-                    site=outer_item.site,
-                    validate_certs=False,
-                    api_user=checkmk_var_api_user,
-                    api_secret=checkmk_var_api_secret)
-              }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Set customer attribute."
+  ansible.builtin.set_fact:
+    checkmk_var_customer: "{{ 'provider' if outer_item.edition == 'cme' else None }}"
 
-- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify local connection."
-  ansible.builtin.assert:
-    that: "__checkmk_var_site.status_connection.connection.socket_type == 'local'"
-  vars:
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all sites."
+  ansible.builtin.set_fact:
+    __checkmk_var_sites: "{{ lookup('checkmk.general.sites',
+                        server_url=checkmk_var_server_url,
+                        site=outer_item.site,
+                        validate_certs=False,
+                        api_user=checkmk_var_api_user,
+                        api_secret=checkmk_var_api_secret) }}"
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get single site."
+  ansible.builtin.set_fact:
     __checkmk_var_site: "{{ lookup('checkmk.general.site',
-                    outer_item.site,
-                    server_url=checkmk_var_server_url,
-                    site=outer_item.site,
-                    validate_certs=False,
-                    api_user=checkmk_var_api_user,
-                    api_secret=checkmk_var_api_secret)
-              }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
+                        outer_item.site,
+                        server_url=checkmk_var_server_url,
+                        site=outer_item.site,
+                        validate_certs=False,
+                        api_user=checkmk_var_api_user,
+                        api_secret=checkmk_var_api_secret) }}"
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify configuration of '{{ __checkmk_var_site.basic_settings.site_id }}'."
+  ansible.builtin.assert:
+    that:
+      - "__checkmk_var_site.status_connection.connection.socket_type == 'local'"
+      - "__checkmk_var_site.status_connection.status_host.status_host_set == 'disabled'"
+      - "__checkmk_var_site.status_connection.proxy.use_livestatus_daemon == 'direct'"
+      - "__checkmk_var_site.configuration_connection.enable_replication == false"
+    success_msg: "All attributes as expected for {{ __checkmk_var_site.basic_settings.site_id }}."
+
+- name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify configuration of {{ item.extensions.basic_settings.site_id }}."
+  ansible.builtin.assert:
+    that:
+      - "item.extensions.status_connection.connection.socket_type == 'local'"
+      - "item.extensions.status_connection.status_host.status_host_set == 'disabled'"
+      - "item.extensions.status_connection.proxy.use_livestatus_daemon == 'direct'"
+      - "item.extensions.configuration_connection.enable_replication == false"
+    success_msg: "All attributes as expected for {{ item.extensions.basic_settings.site_id }}."
+  loop: "{{ __checkmk_var_sites }}"
+  loop_control:
+    label: "{{ item.id }}"
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
     - name: "Set checkmk_var_server_url for isolated testing."
       ansible.builtin.set_fact:
         checkmk_var_server_url: "http://127.0.0.1:5104/"
 
-    - name: "Test plugin with variables from inventory."
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify configuration of '{{ __checkmk_var_site.basic_settings.site_id }}'."
       ansible.builtin.assert:
-        that: "__checkmk_var_site.status_connection.connection.socket_type == 'local'"
+        that:
+          - "__checkmk_var_site.status_connection.connection.socket_type == 'local'"
+          - "__checkmk_var_site.status_connection.status_host.status_host_set == 'disabled'"
+          - "__checkmk_var_site.status_connection.proxy.use_livestatus_daemon == 'direct'"
+          - "__checkmk_var_site.configuration_connection.enable_replication == false"
+        success_msg: "All attributes as expected for {{ __checkmk_var_site.basic_settings.site_id }}."
       vars:
         __checkmk_var_site: "{{ lookup('checkmk.general.site', outer_item.site) }}"
+
+    - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify configuration of '{{ outer_item.site }}''."
+      ansible.builtin.assert:
+        that:
+          - "item.extensions.status_connection.connection.socket_type == 'local'"
+          - "item.extensions.status_connection.status_host.status_host_set == 'disabled'"
+          - "item.extensions.status_connection.proxy.use_livestatus_daemon == 'direct'"
+          - "item.extensions.configuration_connection.enable_replication == false"
+        success_msg: "All attributes as expected for {{ item.extensions.basic_settings.site_id }}."
+      vars:
+        __checkmk_var_sites: "{{ lookup('checkmk.general.sites') }}"
+      loop: "{{ __checkmk_var_sites }}"
+      loop_control:
+        label: "{{ item.id }}"


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
There are several lookup plugins who exist twice for good reason.
Currently, we have integration tests for every single one of them.
To me, it makes sense to simplify this and have one integration test per set.
This reduces overall complexity and overhead significantly, while the risk of having flaky tests or false positives is rather small.

## What is the new behavior?
Integration tests now are combined for lookup module "pairs".
While merging the existing tests, improvements to the overall test logic were implemented as well.
The testing scope should at least be the same as before, potentially better.

## Other information
Once this has been merged into `main`, we can also remove duplicate labels. Check the changed files for the auto labelers.

ToDo: Can we improve the tests `lookup_rules` and `lookup_rulesets` as well, or are they fine as they are?