### PR TITLE
Fix Molecule on Podman

### DIFF
--- a/.github/workflows/_template-molecule-test.yaml
+++ b/.github/workflows/_template-molecule-test.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Checkmk ${{ matrix.checkmk }}
     strategy:
       fail-fast: false

--- a/roles/agent/molecule/2.2.0/molecule.yml
+++ b/roles/agent/molecule/2.2.0/molecule.yml
@@ -9,33 +9,50 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
 provisioner:
   name: ansible
+  connection_options:
+    ansible_connection: podman
   config_options:
     defaults:
       roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."

--- a/roles/agent/molecule/2.3.0/molecule.yml
+++ b/roles/agent/molecule/2.3.0/molecule.yml
@@ -9,33 +9,50 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
 provisioner:
   name: ansible
+  connection_options:
+    ansible_connection: podman
   config_options:
     defaults:
       roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."

--- a/roles/agent/molecule/2.4.0/molecule.yml
+++ b/roles/agent/molecule/2.4.0/molecule.yml
@@ -9,39 +9,59 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian13
     image: docker.io/geerlingguy/docker-debian13-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux10
     image: docker.io/geerlingguy/docker-rockylinux10-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
 provisioner:
   name: ansible
+  connection_options:
+    ansible_connection: podman
   config_options:
     defaults:
       roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."

--- a/roles/server/molecule/2.2.0/molecule.yml
+++ b/roles/server/molecule/2.2.0/molecule.yml
@@ -9,33 +9,50 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
 provisioner:
   name: ansible
+  connection_options:
+    ansible_connection: podman
   config_options:
     defaults:
       roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."

--- a/roles/server/molecule/2.3.0/molecule.yml
+++ b/roles/server/molecule/2.3.0/molecule.yml
@@ -9,33 +9,50 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
 provisioner:
   name: ansible
+  connection_options:
+    ansible_connection: podman
   config_options:
     defaults:
       roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."

--- a/roles/server/molecule/2.4.0/molecule.yml
+++ b/roles/server/molecule/2.4.0/molecule.yml
@@ -9,45 +9,68 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: ubuntu2404
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian11
     image: docker.io/geerlingguy/docker-debian11-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian12
     image: docker.io/geerlingguy/docker-debian12-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: debian13
     image: docker.io/geerlingguy/docker-debian13-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
   - name: rockylinux10
     image: docker.io/geerlingguy/docker-rockylinux10-ansible
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     pre_build_image: true
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns: host
     systemd: always
 provisioner:
   name: ansible
+  connection_options:
+    ansible_connection: podman
   config_options:
     defaults:
       roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Currently, Molecule tests on Podman do not work on Ubuntu 24.04 runners.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Bump runner images for Molecule tests to Ubuntu 24.04.
- Add necessary `cgroupns` and `volumes` options to use cgroups from host.
- Switch connection for Ansible provisioner to native `podman`.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.