### PR TITLE
Fix user module: Parameter renaming "mega_menu_icons" -> "main _menu_icons" (with Checkmk 2.5.0)

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -514,7 +514,9 @@ def run_module():
         interface_theme=dict(type="str", choices=["default", "dark", "light"]),
         sidebar_position=dict(type="str", choices=["left", "right"]),
         navigation_bar_icons=dict(type="str", choices=["hide", "show"]),
-        main_menu_icons=dict(type="str", choices=["topic", "entry"], aliases=["mega_menu_icons"]),
+        main_menu_icons=dict(
+            type="str", choices=["topic", "entry"], aliases=["mega_menu_icons"]
+        ),
         show_mode=dict(
             type="str",
             choices=[
@@ -544,7 +546,6 @@ def run_module():
             changed=False,
         )
         exit_module(module, result=result, logger=logger)
-
 
     # Use the parameters to initialize some common api variables
     user = UserAPI(module)


### PR DESCRIPTION
## Pull request type
Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
Issue Number: #806

## What is the new behavior?
- The user module is now compatible with Checkmk 2.5.0 (and still is with previous versions)
- To call the module, you can use both, "mega_menu_icons" (as before) and "main_menu_icons"

## Other information
When 2.4.0 runs out of support, we can fade out the alias "mega_menu_icons", which will be a breaking change.
