### PR TITLE
Remove unnecessary `run_once` and `delegate_to`

### DIFF
--- a/tests/integration/targets/activation/tasks/test.yml
+++ b/tests/integration/targets/activation/tasks/test.yml
@@ -9,8 +9,6 @@
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
   host:
@@ -24,8 +22,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate without explicit site."
@@ -34,8 +30,6 @@
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
   host:
@@ -46,8 +40,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate forcing foreign changes."
@@ -57,8 +49,6 @@
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
     force_foreign_changes: true
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
   host:
@@ -72,8 +62,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate with explicit site."
@@ -85,8 +73,6 @@
     force_foreign_changes: 'false'
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
   host:
@@ -97,8 +83,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate with explicit site and redirect."
@@ -111,11 +95,7 @@
     force_foreign_changes: 'false'
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   activation:
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/bakery/tasks/test.yml
+++ b/tests/integration/targets/bakery/tasks/test.yml
@@ -15,8 +15,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -28,8 +26,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bake all agents."
   bakery:
@@ -38,8 +34,6 @@
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
     state: "baked"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Sign all agents."
   bakery:
@@ -50,8 +44,6 @@
     signature_key_id: "{{ checkmk_var_signature_key_id }}"
     signature_key_passphrase: "{{ checkmk_var_signature_key_passphrase }}"
     state: "signed"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bake and Sign all agents."
   bakery:
@@ -62,8 +54,6 @@
     signature_key_id: "{{ checkmk_var_signature_key_id }}"
     signature_key_passphrase: "{{ checkmk_var_signature_key_passphrase }}"
     state: "baked_signed"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
   host:
@@ -74,8 +64,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -86,12 +74,8 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   bakery:
     state: "baked"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/contact_group/tasks/test.yml
+++ b/tests/integration/targets/contact_group/tasks/test.yml
@@ -13,8 +13,6 @@
     name: "{{ item.name }}"
     title: "{{ item.title | default(item.name) }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_contact_groups_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test for mutually exclusive module args: 'groups|name'."
@@ -28,8 +26,6 @@
     title: "{{ item.title | default(item.name) }}"
     groups: "{{ checkmk_var_contact_groups_create }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_contact_groups_create }}"
   register: __checkmk_var_result_mutex_loop
   failed_when: "'parameters are mutually exclusive: groups|name' not in __checkmk_var_result_mutex_loop.msg"
@@ -43,8 +39,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Modify part of contact groups (also checks for idempotency!)."
   contact_group:
@@ -56,8 +50,6 @@
     name: "{{ item.name | default(item.name) }}"
     title: "{{ item.title }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_contact_groups_modify }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -69,8 +61,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete contact groups."
   contact_group:
@@ -81,8 +71,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_contact_groups_delete }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -94,8 +82,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete contact groups that were created at the beginning (also check for idempotency)."
   contact_group:
@@ -106,8 +92,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_contact_groups_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -119,8 +103,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk create contact groups."
   contact_group:
@@ -131,8 +113,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_contact_groups_create }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test for mutually exclusive module args: 'groups|name'."
   contact_group:
@@ -144,8 +124,6 @@
     groups: "{{ checkmk_var_contact_groups_create }}"
     name: "test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_mutex_single
   failed_when: "'parameters are mutually exclusive: groups|name' not in __checkmk_var_result_mutex_single.msg"
 
@@ -159,8 +137,6 @@
     groups: "{{ checkmk_var_contact_groups_create }}"
     title: "Test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_ineffective
   failed_when: |
     "'title' has only effect when 'name' is defined and not 'groups'" not in __checkmk_var_result_ineffective.msg
@@ -174,8 +150,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_contact_groups_modify }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk delete contact groups."
   contact_group:
@@ -186,8 +160,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_contact_groups_delete }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk delete contact groups checking for idempotency."
   contact_group:
@@ -198,8 +170,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_contact_groups_create }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:
@@ -210,14 +180,10 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   contact_group:
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_contact_groups_create }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/dcd/tasks/test.yml
+++ b/tests/integration/targets/dcd/tasks/test.yml
@@ -30,7 +30,6 @@
         restrict_source_hosts:
           - "boar"
     state: "present"
-  delegate_to: localhost
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create a DCD conf.  Again!"
   dcd:
@@ -59,7 +58,6 @@
         restrict_source_hosts:
           - "boar"
     state: "present"
-  delegate_to: localhost
   register: __checkmk_var_result_dcd_create
   failed_when: __checkmk_var_result_dcd_create.changed
 
@@ -74,4 +72,3 @@
       dcd_id: "PiggybackBoar"
       site: "{{ outer_item.site }}"
     state: "absent"
-  delegate_to: localhost

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -15,8 +15,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "Run Single Discoveries."
@@ -29,8 +27,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "refresh"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update host labels."
@@ -41,8 +37,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "only_host_labels"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Remove vanished services."
@@ -53,8 +47,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "remove"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Add undecided services."
@@ -65,8 +57,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "new"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update service labels. (Should fail < 2.3.0)"
@@ -77,8 +67,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "only_service_labels"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
       register: __checkmk_var_result_labels
       failed_when: "'State only_service_labels is not supported with this Checkmk version' not in __checkmk_var_result_labels.msg"
@@ -92,8 +80,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "monitor_undecided_services"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
       register: __checkmk_var_result_undecided_pre_23
       failed_when: "'State monitor_undecided_services is not supported with this Checkmk version' not in __checkmk_var_result_undecided_pre_23.msg"
@@ -107,8 +93,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "only_service_labels"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
       when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
 
@@ -120,8 +104,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "monitor_undecided_services"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
       register: __checkmk_var_result_undecided_post_23
       failed_when: "'State monitor_undecided_services is only supported in bulk mode.' not in __checkmk_var_result_undecided_post_23.msg"
@@ -135,8 +117,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "tabula_rasa"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
       when: "not '2.1' in outer_item.version"
 
@@ -148,8 +128,6 @@
         api_secret: "{{ checkmk_var_api_secret }}"
         host_name: "{{ item.name }}"
         state: "fix_all"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -161,8 +139,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
   host:
@@ -173,8 +149,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -185,8 +159,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "Run Bulk Discoveries."
   when: "not '2.0.0' in outer_item.version"
@@ -203,8 +175,6 @@
           site: "{{ outer_item.site }}"
           ipaddress: 127.0.0.1
         state: "present"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
       loop: "{{ checkmk_var_hosts }}"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Refresh (tabula_rasa) services."
@@ -216,7 +186,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "refresh"
         bulk_size: 5
-      delegate_to: localhost
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Update host labels."
       discovery:
@@ -227,7 +196,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "only_host_labels"
         bulk_size: 5
-      delegate_to: localhost
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Remove vanished services."
       discovery:
@@ -238,7 +206,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "remove"
         bulk_size: 5
-      delegate_to: localhost
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Update service labels. (Should fail < 2.3.0)"
       discovery:
@@ -249,7 +216,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "only_service_labels"
         bulk_size: 5
-      delegate_to: localhost
       register: __checkmk_var_result_labels_pre_23
       failed_when: "'State only_service_labels is not supported with this Checkmk version.' not in __checkmk_var_result_labels_pre_23.msg"
       when: "not '2.3.0' in outer_item.version and not '2.4.0' in outer_item.version"
@@ -263,7 +229,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "monitor_undecided_services"
         bulk_size: 5
-      delegate_to: localhost
       register: __checkmk_var_result_labels_post_23
       failed_when: "'State monitor_undecided_services is not supported with this Checkmk version.' not in __checkmk_var_result_labels_post_23.msg"
       when: "not '2.3.0' in outer_item.version and not '2.4.0' in outer_item.version"
@@ -277,7 +242,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "only_service_labels"
         bulk_size: 5
-      delegate_to: localhost
       when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Monitor undecided services. (only 2.3)"
@@ -289,7 +253,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "monitor_undecided_services"
         bulk_size: 5
-      delegate_to: localhost
       when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Add undecided services to monitoring."
@@ -301,7 +264,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "new"
         bulk_size: 5
-      delegate_to: localhost
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk: Discover hosts (fix_all)."
       discovery:
@@ -312,7 +274,6 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "fix_all"
         bulk_size: 5
-      delegate_to: localhost
 
     - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
       activation:
@@ -323,16 +284,12 @@
         force_foreign_changes: true
         sites:
           - "{{ outer_item.site }}"
-      delegate_to: localhost
-      run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   discovery:
     hosts: "{{ checkmk_var_host_names }}"
     state: "fix_all"
     bulk_size: 5
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
@@ -344,8 +301,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -356,5 +311,3 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/downtime/tasks/test.yml
+++ b/tests/integration/targets/downtime/tasks/test.yml
@@ -15,8 +15,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Discover hosts."
@@ -27,8 +25,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     host_name: "{{ item.name }}"
     state: "fix_all"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run activation."
@@ -39,8 +35,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     force_foreign_changes: true
     redirect: true
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Wait for the activation to finish."
   ansible.builtin.wait_for:
@@ -331,8 +325,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run activation."
@@ -342,8 +334,6 @@
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
     force_foreign_changes: true
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   downtime:
@@ -352,6 +342,5 @@
     service_descriptions:
       - "Check_MK"
     state: absent
-  delegate_to: localhost
   loop: "{{ checkmk_var_hosts }}"
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/folder/tasks/test.yml
+++ b/tests/integration/targets/folder/tasks/test.yml
@@ -16,8 +16,6 @@
     path: "{{ item.path }}"
     name: "{{ item.name }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -29,8 +27,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete folders."
   folder:
@@ -41,8 +37,6 @@
     path: "{{ item.path }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -54,8 +48,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create folders for attributes test."
   folder:
@@ -67,8 +59,6 @@
     name: "{{ checkmk_var_folder_attr_test.name }}"
     attributes: "{{ checkmk_var_folder_attr_test.attributes }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update folder attributes without specifying title (name)."
   folder:
@@ -81,8 +71,6 @@
     update_attributes:
       tag_criticality: "test"
       tag_networking: "wan"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check the idempotency of Update attributes."
   folder:
@@ -94,8 +82,6 @@
     update_attributes:
       tag_criticality: "test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_update_attributes
   failed_when: __checkmk_var_result_update_attributes.changed | bool
 
@@ -108,8 +94,6 @@
     path: "{{ checkmk_var_folder_attr_test.path }}"
     name: "{{ checkmk_var_folder_attr_test.name }} Modified"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Remove folder attributes without specifying title (name)."
   folder:
@@ -121,8 +105,6 @@
     state: "present"
     remove_attributes:
       - "tag_networking"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check the idempotency of Remove attributes."
   folder:
@@ -134,8 +116,6 @@
     remove_attributes:
       - "tag_networking"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_remove_attributes
   failed_when: __checkmk_var_result_remove_attributes.changed | bool
 
@@ -148,8 +128,6 @@
     path: "{{ item.path }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -161,8 +139,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create folders for defaults test."
   folder:
@@ -174,8 +150,6 @@
     name: "{{ item.name | default(omit) }}"
     state: "present"
   loop: "{{ checkmk_var_folders_defaults_test }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:
@@ -186,8 +160,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Print created folders."
   ansible.builtin.debug:
@@ -202,8 +174,6 @@
                     api_secret=checkmk_var_api_secret)
               }}"
     __checkmk_var_folder_title: "{{ dict((__checkmk_var_result_print | map(attribute='id') | map('regex_replace', '~', '/')) | zip(__checkmk_var_result_print | map(attribute='title'))) }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify created folders."
   ansible.builtin.assert:
@@ -219,8 +189,6 @@
               }}"
     __checkmk_var_folder_title: "{{ dict((__checkmk_var_result_verify | map(attribute='id') | map('regex_replace', '~', '/')) | zip(__checkmk_var_result_verify | map(attribute='title'))) }}"
   loop: "{{ checkmk_var_folders_defaults_test }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete folders."
   folder:
@@ -232,8 +200,6 @@
     name: "{{ item.name | default(omit) }}"
     state: "absent"
   loop: "{{ checkmk_var_folders_defaults_test }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:
@@ -244,8 +210,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   folder:
@@ -253,6 +217,4 @@
     name: "{{ item.name | default(omit) }}"
     state: "absent"
   loop: "{{ checkmk_var_folders_defaults_test }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/host/tasks/test.yml
+++ b/tests/integration/targets/host/tasks/test.yml
@@ -12,8 +12,6 @@
     path: "{{ item.path }}"
     name: "{{ item.name }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
@@ -28,8 +26,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -41,8 +37,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify host folder."
   ansible.builtin.assert:
@@ -56,8 +50,6 @@
                     api_user=checkmk_var_api_user,
                     api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
@@ -69,8 +61,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -82,8 +72,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create host with update_attributes without folder."
   host:
@@ -99,8 +87,6 @@
         foo: bar
       alias: test
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency on update_attributes for only a subset of attributes."
@@ -115,8 +101,6 @@
         foo: bar
       alias: test
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Remove Attributes of host."
@@ -129,8 +113,6 @@
     remove_attributes:
       - alias
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency on remove_attributes."
@@ -143,8 +125,6 @@
     remove_attributes:
       - alias
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
@@ -156,8 +136,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -169,8 +147,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 ### Cluster Host Tests
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create hosts."
@@ -185,8 +161,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -198,8 +172,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create cluster hosts."
   host:
@@ -214,8 +186,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -227,8 +197,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency of create cluster hosts."
   host:
@@ -243,8 +211,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Modify nodes in cluster host."
@@ -260,8 +226,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   vars:
     __checkmk_var_first: "{{ checkmk_var_cluster_hosts[0] }}"
     __checkmk_var_second: "{{ checkmk_var_cluster_hosts[1] }}"
@@ -275,8 +239,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency, Modify nodes in cluster host."
   host:
@@ -291,8 +253,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   vars:
     __checkmk_var_first: "{{ checkmk_var_cluster_hosts[0] }}"
     __checkmk_var_second: "{{ checkmk_var_cluster_hosts[1] }}"
@@ -310,8 +270,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts_add_nodes }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -323,8 +281,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency of Add nodes to cluster hosts."
   host:
@@ -339,8 +295,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts_add_nodes }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -352,8 +306,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Remove nodes from cluster hosts."
   host:
@@ -368,8 +320,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts_remove_nodes }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -381,8 +331,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency of nodes removal from cluster hosts."
   host:
@@ -397,8 +345,6 @@
       site: "{{ outer_item.site }}"
       ipaddress: 127.0.0.1
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts_remove_nodes }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -410,8 +356,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 ###
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete cluster hosts."
@@ -423,8 +367,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -436,8 +378,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency of delete cluster hosts."
   host:
@@ -448,8 +388,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create cluster host with update_attributes without folder."
@@ -467,8 +405,6 @@
         foo: bar
       alias: test
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency on update_attributes for only a subset of attributes."
@@ -484,8 +420,6 @@
         foo: bar
       alias: test
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Remove Attributes of cluster host."
@@ -499,8 +433,6 @@
     remove_attributes:
       - alias
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Check idempotency on remove_attributes."
@@ -514,8 +446,6 @@
     remove_attributes:
       - alias
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete cluster hosts."
@@ -528,8 +458,6 @@
     nodes: "{{ item.nodes }}"
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_cluster_hosts }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete hosts."
@@ -541,8 +469,6 @@
     name: "{{ item.name }}"
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_hosts }}"
 
 ###
@@ -555,8 +481,6 @@
     path: "{{ item.path }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_folders }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -568,8 +492,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   host:
@@ -577,6 +499,4 @@
     folder: "{{ item.folder | default(omit) }}"
     state: "absent"
   loop: "{{ checkmk_var_hosts }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/host_group/tasks/test.yml
+++ b/tests/integration/targets/host_group/tasks/test.yml
@@ -13,8 +13,6 @@
     name: "{{ item.name }}"
     title: "{{ item.title | default(item.name) }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_host_groups_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test for mutually exclusive module args: 'groups|name'."
@@ -28,8 +26,6 @@
     title: "{{ item.title | default(item.name) }}"
     groups: checkmk_var_host_groups_create
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_host_groups_create }}"
   register: __checkmk_var_result_mutex_loop
   failed_when: "'parameters are mutually exclusive: groups|name' not in __checkmk_var_result_mutex_loop.msg"
@@ -43,8 +39,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Modify part of host groups (also checks for idempotency!)."
   host_group:
@@ -56,8 +50,6 @@
     name: "{{ item.name | default(item.name) }}"
     title: "{{ item.title }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_host_groups_modify }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -69,8 +61,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete host groups."
   host_group:
@@ -81,8 +71,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_host_groups_delete }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -94,8 +82,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete host groups that were created at the beginning (also check for idempotency)."
   host_group:
@@ -106,8 +92,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_host_groups_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -119,8 +103,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk create host groups."
   host_group:
@@ -131,8 +113,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_host_groups_create }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test for mutually exclusive module args: 'groups|name'."
   host_group:
@@ -144,8 +124,6 @@
     groups: "{{ checkmk_var_host_groups_create }}"
     name: "test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_mutex_single
   failed_when: "'parameters are mutually exclusive: groups|name' not in __checkmk_var_result_mutex_single.msg"
 
@@ -159,8 +137,6 @@
     groups: "{{ checkmk_var_host_groups_create }}"
     title: "Test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_ineffective
   failed_when: |
     "'title' has only effect when 'name' is defined and not 'groups'" not in __checkmk_var_result_ineffective.msg
@@ -174,8 +150,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_host_groups_modify }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk delete host groups."
   host_group:
@@ -186,8 +160,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_host_groups_delete }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk delete host groups that were created at the beginning (also check for idempotency)."
   host_group:
@@ -198,8 +170,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_host_groups_create }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:
@@ -210,5 +180,3 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]

--- a/tests/integration/targets/ldap/tasks/test.yml
+++ b/tests/integration/targets/ldap/tasks/test.yml
@@ -11,11 +11,9 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     ldap_config: "{{ item.ldap_config }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_ldap_connections }}"
   loop_control:
     label: "{{ item.ldap_config.general_properties.id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create an LDAP connection. Again."
   ldap:
@@ -25,11 +23,9 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     ldap_config: "{{ item.ldap_config }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_ldap_connections }}"
   loop_control:
     label: "{{ item.ldap_config.general_properties.id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_create
   failed_when: __checkmk_var_result_create.changed | bool
 
@@ -51,11 +47,9 @@
       groups: "{{ item.ldap_config.groups | default(omit) }}"
       sync_plugins: "{{ item.ldap_config.sync_plugins | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_ldap_connections }}"
   loop_control:
     label: "{{ item.ldap_config.general_properties.id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update an LDAP connection. Again."
   ldap:
@@ -75,11 +69,9 @@
       groups: "{{ item.ldap_config.groups | default(omit) }}"
       sync_plugins: "{{ item.ldap_config.sync_plugins | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_ldap_connections }}"
   loop_control:
     label: "{{ item.ldap_config.general_properties.id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_create
   failed_when: __checkmk_var_result_create.changed | bool
 
@@ -93,11 +85,9 @@
       general_properties:
         id: "{{ item.ldap_config.general_properties.id }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ checkmk_var_ldap_connections }}"
   loop_control:
     label: "{{ item.ldap_config.general_properties.id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete LDAP connection. Again."
   ldap:
@@ -109,10 +99,8 @@
       general_properties:
         id: "{{ item.ldap_config.general_properties.id }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ checkmk_var_ldap_connections }}"
   loop_control:
     label: "{{ item.ldap_config.general_properties.id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_delete
   failed_when: __checkmk_var_result_delete.changed | bool

--- a/tests/integration/targets/lookup_bakery/tasks/test.yml
+++ b/tests/integration/targets/lookup_bakery/tasks/test.yml
@@ -14,7 +14,6 @@
                     api_user=checkmk_var_api_user,
                     api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
   register: __checkmk_var_result_bakery
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify bakery status."
@@ -27,8 +26,6 @@
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
     - name: "Set checkmk_var_server_url for isolated testing."

--- a/tests/integration/targets/lookup_rules/tasks/test.yml
+++ b/tests/integration/targets/lookup_rules/tasks/test.yml
@@ -12,8 +12,6 @@
     ruleset: "{{ item.ruleset }}"
     rule: "{{ item.rule }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rules }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all rules of a ruleset."
@@ -29,8 +27,6 @@
                   api_secret=checkmk_var_api_secret)
               }}"
   register: __checkmk_var_cpu_load_ruleset
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - compare rules with ansible data."
   ansible.builtin.assert:
@@ -45,8 +41,6 @@
                       api_user=checkmk_var_api_user,
                       api_secret=checkmk_var_api_secret)
                   }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rulesets }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - filter for certain rulesets."
@@ -61,8 +55,6 @@
                       api_user=checkmk_var_api_user,
                       api_secret=checkmk_var_api_secret)
                   }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rulesets }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - filter for certain rulesets and check the count."
@@ -79,8 +71,6 @@
                       api_user=checkmk_var_api_user,
                       api_secret=checkmk_var_api_secret)
                   }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rulesets }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get each single rule of a ruleset."
@@ -95,14 +85,10 @@
                       api_user=checkmk_var_api_user,
                       api_secret=checkmk_var_api_secret)
                   }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ __checkmk_var_cpu_load_ruleset.__checkmk_var_one_ruleset }}"
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
     - name: "Set checkmk_var_server_url for isolated testing."

--- a/tests/integration/targets/lookup_rulesets/tasks/test.yml
+++ b/tests/integration/targets/lookup_rulesets/tasks/test.yml
@@ -12,8 +12,6 @@
     ruleset: "{{ item.ruleset }}"
     rule: "{{ item.rule }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rules }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get all rulesets."
@@ -30,8 +28,6 @@
                   api_user=checkmk_var_api_user,
                   api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Get list of all rulesets."
   ansible.builtin.debug:
@@ -46,8 +42,6 @@
              api_user=checkmk_var_api_user,
              api_secret=checkmk_var_api_secret)
          }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop_control:
     label: "{{ item.id }}"
 
@@ -65,8 +59,6 @@
                   api_user=checkmk_var_api_user,
                   api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Verify number of rules using lookup-ruleset."
   ansible.builtin.assert:
@@ -81,8 +73,6 @@
                       api_user=checkmk_var_api_user,
                       api_secret=checkmk_var_api_secret)
                   }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_ruleset_regexes }}"
 
 # We need this hack to overwrite the colliding global variable
@@ -97,8 +87,6 @@
     that: "__checkmk_var_ruleset.number_of_rules == 1"
   vars:
     __checkmk_var_ruleset: "{{ lookup('checkmk.general.ruleset', ruleset=item) }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_ruleset_regexes }}"
   when: outer_item.site == "stable_cme"
 
@@ -107,14 +95,10 @@
     var: __checkmk_var_rulesets
   vars:
     __checkmk_var_rulesets: "{{ lookup('checkmk.general.rulesets', regex='file', rulesets_used=False, rulesets_deprecated=False) }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
     - name: "Set checkmk_var_server_url for isolated testing."

--- a/tests/integration/targets/lookup_version/tasks/test.yml
+++ b/tests/integration/targets/lookup_version/tasks/test.yml
@@ -16,12 +16,9 @@
                     api_user=checkmk_var_api_user,
                     api_secret=checkmk_var_api_secret)
               }}"
-  delegate_to: localhost
 
 # We need this hack to overwrite the colliding global variable
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Use variables from inventory."
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   when: outer_item.site == "stable_cme"
   block:
     - name: "Set checkmk_var_server_url for isolated testing."

--- a/tests/integration/targets/password/tasks/test.yml
+++ b/tests/integration/targets/password/tasks/test.yml
@@ -18,7 +18,6 @@
     owner: "{{ item.owner }}"
     shared: "{{ item.shared }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_passwords_create }}"
   no_log: false
 
@@ -36,7 +35,6 @@
     owner: "{{ item.owner }}"
     shared: "{{ item.shared }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_passwords_create_cme }}"
   no_log: false
   when: (outer_item.edition == "cme")
@@ -54,7 +52,6 @@
     name: "{{ item.name }}"
     password: "{{ item.password }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_passwords_create }}"
   no_log: false
   when: (outer_item.edition == "cme")
@@ -70,8 +67,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update passwords."
   password:
@@ -88,7 +83,6 @@
     owner: "{{ item.owner | default(omit) }}"
     shared: "{{ item.shared | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_passwords_update }}"
   no_log: false
 
@@ -101,8 +95,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete a password."
   password:
@@ -114,7 +106,6 @@
     name: "{{ item.name }}"
     title: "{{ item.title }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ checkmk_var_passwords_delete }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -126,8 +117,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   password:
@@ -136,6 +125,4 @@
     title: "{{ item.title }}"
     state: "absent"
   loop: "{{ checkmk_var_passwords_delete }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/rule/tasks/test.yml
+++ b/tests/integration/targets/rule/tasks/test.yml
@@ -15,8 +15,6 @@
     ruleset: "{{ item.ruleset }}"
     rule: "{{ item.rule }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rules }}"
   register: __checkmk_var_created_rules
 
@@ -29,8 +27,6 @@
     ruleset: "{{ item.ruleset }}"
     rule: "{{ item.rule }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_rules }}"
   register: __checkmk_var_result_rules_create
   failed_when: __checkmk_var_result_rules_create.changed
@@ -50,8 +46,6 @@
         description: "New description"
       value_raw: "{{ item.content.extensions.value_raw | string }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ __checkmk_var_created_rules.results }}"
   loop_control:
     label: "{{ item.content.id }}"
@@ -71,8 +65,6 @@
         description: "New description"
       value_raw: "{{ item.content.extensions.value_raw | string }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ __checkmk_var_created_rules.results }}"
   loop_control:
     label: "{{ item.content.id }}"
@@ -94,8 +86,6 @@
         description: "Even newer description"
       value_raw: "{{ item.extensions.value_raw | string }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ lookup('checkmk.general.rules',
       ruleset='checkgroup_parameters:filesystem',
       comment_regex='Ansible managed',
@@ -117,8 +107,6 @@
     rule:
       rule_id: "{{ item.content.id }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ __checkmk_var_created_rules.results }}"
   loop_control:
     label: "{{ item.content.id }}"
@@ -132,8 +120,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete rules. Again."
   rule:
@@ -145,8 +131,6 @@
     rule:
       rule_id: "{{ item.content.id }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ __checkmk_var_created_rules.results }}"
   loop_control:
     label: "{{ item.content.id }}"
@@ -162,6 +146,4 @@
   loop: "{{ __checkmk_var_created_rules.results }}"
   loop_control:
     label: "{{ item.content.id }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/service_group/tasks/test.yml
+++ b/tests/integration/targets/service_group/tasks/test.yml
@@ -13,8 +13,6 @@
     name: "{{ item.name }}"
     title: "{{ item.title | default(item.name) }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_service_groups_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test for mutually exclusive module args: 'groups|name'."
@@ -28,8 +26,6 @@
     title: "{{ item.title | default(item.name) }}"
     groups: checkmk_var_service_groups_create
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_service_groups_create }}"
   register: __checkmk_var_result_mutex_loop
   failed_when: "'parameters are mutually exclusive: groups|name' not in __checkmk_var_result_mutex_loop.msg"
@@ -43,8 +39,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Modify part of service groups (also checks for idempotency!)."
   service_group:
@@ -56,8 +50,6 @@
     name: "{{ item.name | default(item.name) }}"
     title: "{{ item.title }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_service_groups_modify }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -69,8 +61,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete service groups."
   service_group:
@@ -81,8 +71,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_service_groups_delete }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -94,8 +82,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete service groups that were created at the beginning (also check for idempotency)."
   service_group:
@@ -106,8 +92,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_service_groups_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -119,8 +103,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk create service groups."
   service_group:
@@ -131,8 +113,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_service_groups_create }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test for mutually exclusive module args: 'groups|name'."
   service_group:
@@ -144,8 +124,6 @@
     groups: "{{ checkmk_var_service_groups_create }}"
     name: "test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_mutex_single
   failed_when: "'parameters are mutually exclusive: groups|name' not in __checkmk_var_result_mutex_single.msg"
 
@@ -159,8 +137,6 @@
     groups: "{{ checkmk_var_service_groups_create }}"
     title: "Test"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_ineffective
   failed_when: |
     "'title' has only effect when 'name' is defined and not 'groups'" not in __checkmk_var_result_ineffective.msg
@@ -174,8 +150,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_service_groups_modify }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk delete service groups."
   service_group:
@@ -186,8 +160,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_service_groups_delete }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Bulk delete service groups checking for idempotency)."
   service_group:
@@ -198,8 +170,6 @@
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_service_groups_create }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
   activation:
@@ -210,14 +180,10 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   service_group:
     customer: "{{ (checkmk_var_customer != None) | ternary(checkmk_var_customer, omit) }}"  # See PR #427
     groups: "{{ checkmk_var_service_groups_create }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/site/tasks/test.yml
+++ b/tests/integration/targets/site/tasks/test.yml
@@ -13,11 +13,9 @@
     site_connection:
       site_config: "{{ item.site_config }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create site connection again."
   site:
@@ -29,11 +27,9 @@
     site_connection:
       site_config: "{{ item.site_config }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Log in to remote site."
   site:
@@ -45,11 +41,9 @@
     site_connection:
       authentication: "{{ item.authentication }}"
     state: "login"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Log in to remote site again."
   site:
@@ -61,11 +55,9 @@
     site_connection:
       authentication: "{{ item.authentication }}"
     state: "login"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_login
   # failed_when: __checkmk_var_result_login.changed | bool  # TODO: Temporarily disabled. See #899.
 
@@ -83,11 +75,9 @@
         configuration_connection:
         status_connection:
     state: "present"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update remote site again. "
   site:
@@ -101,11 +91,9 @@
         basic_settings:
           alias: "{{ item.site_id }} with new alias"
     state: "present"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_update
   failed_when: __checkmk_var_result_update.changed | bool
 
@@ -117,11 +105,9 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     site_id: "{{ item.site_id }}"
     state: "logout"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Log out from remote site again."
   site:
@@ -131,11 +117,9 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     site_id: "{{ item.site_id }}"
     state: "logout"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_logout
   failed_when: __checkmk_var_result_logout.changed | bool
 
@@ -147,11 +131,9 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     site_id: "{{ item.site_id }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete remote site again."
   site:
@@ -161,11 +143,9 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     site_id: "{{ item.site_id }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_delete
   failed_when: __checkmk_var_result_delete.changed | bool
 
@@ -176,7 +156,6 @@
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
     label: "{{ item.site_id }}"
-  delegate_to: localhost
   environment: "{{ __checkmk_var_testing_environment }}"
   register: __checkmk_var_result_environment
   failed_when: __checkmk_var_result_environment.changed | bool

--- a/tests/integration/targets/tag_group/tasks/test.yml
+++ b/tests/integration/targets/tag_group/tasks/test.yml
@@ -11,7 +11,6 @@
     help: "{{ item.help }}"
     tags: "{{ item.tags }}"
     state: "present"
-  delegate_to: localhost
   register: __checkmk_var_result_tag_group_create
   loop: "{{ checkmk_var_tag_groups_create }}"
   failed_when: not __checkmk_var_result_tag_group_create.changed
@@ -22,8 +21,6 @@
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create tag_group again."
   tag_group:
@@ -37,7 +34,6 @@
     help: "{{ item.help }}"
     tags: "{{ item.tags }}"
     state: "present"
-  delegate_to: localhost
   register: __checkmk_var_result_tag_group_recreate
   loop: "{{ checkmk_var_tag_groups_create }}"
   failed_when: __checkmk_var_result_tag_group_recreate.changed
@@ -66,7 +62,6 @@
     help: "{{ item.help }}"
     tags: "{{ item.tags }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_tag_groups_update }}"
   register: __checkmk_var_result_tag_group_update
   failed_when: "'You must authorize Checkmk to update the relevant instances using the repair parameter' not in __checkmk_var_result_tag_group_update.msg"
@@ -84,7 +79,6 @@
     tags: "{{ item.tags }}"
     repair: "{{ item.repair | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_tag_groups_update }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate changes."
@@ -93,8 +87,6 @@
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete tag_groups."
   tag_group:
@@ -105,7 +97,6 @@
     name: "{{ item.name }}"
     repair: "{{ item.repair | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
   register: __checkmk_var_result_tag_group_delete
   loop: "{{ checkmk_var_tag_groups_delete }}"
   failed_when: not __checkmk_var_result_tag_group_delete.changed
@@ -116,8 +107,6 @@
     site: "{{ outer_item.site }}"
     api_user: "{{ checkmk_var_api_user }}"
     api_secret: "{{ checkmk_var_api_secret }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete tag_groups again."
   tag_group:
@@ -128,7 +117,6 @@
     name: "{{ item.name }}"
     repair: "{{ item.repair | default(omit) }}"
     state: "absent"
-  delegate_to: localhost
   register: __checkmk_var_result_tag_group_redelete
   loop: "{{ checkmk_var_tag_groups_delete }}"
   failed_when: __checkmk_var_result_tag_group_redelete.changed
@@ -148,7 +136,6 @@
       topic: "{{ item.topic }}"
       title: "{{ item.title }}"
       help: "{{ item.help }}"
-  delegate_to: localhost
   loop: "{{ checkmk_var_aux_tags_create }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create tag_group with aux_tags."
@@ -163,7 +150,6 @@
     help: "{{ item.help }}"
     tags: "{{ item.tags }}"
     state: "present"
-  delegate_to: localhost
   register: __checkmk_var_result_tag_group_with_aux_tags_create
   loop: "{{ checkmk_var_tag_groups_with_aux_tags_create }}"
   failed_when: not __checkmk_var_result_tag_group_with_aux_tags_create.changed
@@ -181,7 +167,6 @@
     tags: "{{ item.tags }}"
     repair: "{{ item.repair | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   register: __checkmk_var_result_tag_group_with_aux_tags_update
   loop: "{{ checkmk_var_tag_groups_with_aux_tags_update }}"
   failed_when: not __checkmk_var_result_tag_group_with_aux_tags_update.changed
@@ -196,6 +181,4 @@
     repair: "{{ item.repair | default(omit) }}"
     state: "present"
   loop: "{{ checkmk_var_tag_groups_with_aux_tags_update }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/timeperiod/tasks/test.yml
+++ b/tests/integration/targets/timeperiod/tasks/test.yml
@@ -15,7 +15,6 @@
     exceptions: "{{ item.exceptions | default(omit) }}"
     exclude: "{{ item.exclude | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_timeperiods_create }}"
   no_log: false
 
@@ -28,8 +27,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Update time periods."
   timeperiod:
@@ -43,7 +40,6 @@
     exceptions: "{{ item.exceptions | default(omit) }}"
     exclude: "{{ item.exclude | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_timeperiods_update }}"
   no_log: false
 
@@ -60,7 +56,6 @@
     exceptions: "{{ item.exceptions | default(omit) }}"
     exclude: "{{ item.exclude | default(omit) }}"
     state: "present"
-  delegate_to: localhost
   loop: "{{ checkmk_var_timeperiods_noupdate }}"
   no_log: false
 
@@ -73,8 +68,6 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 # This should fail.
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Test that a timeperiod which is still in use cannot be deleted."
@@ -85,7 +78,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ checkmk_var_timeperiods_faildelete }}"
   register: __checkmk_var_result_used
   failed_when: "'The time period is still in use' not in __checkmk_var_result_used.msg"
@@ -98,7 +90,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ checkmk_var_timeperiods_deletefirst }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete a time period."
@@ -109,7 +100,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
   loop: "{{ checkmk_var_timeperiods_delete }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -121,14 +111,10 @@
     force_foreign_changes: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Run Module using Environment Variables."
   timeperiod:
     name: "{{ item.name }}"
     state: "absent"
   loop: "{{ checkmk_var_timeperiods_delete }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"

--- a/tests/integration/targets/user/tasks/test.yml
+++ b/tests/integration/targets/user/tasks/test.yml
@@ -13,8 +13,6 @@
     name: "{{ item }}"
     title: "{{ item }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_contact_groups }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Activate."
@@ -27,8 +25,6 @@
     redirect: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create users."
   user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
@@ -59,8 +55,6 @@
     authorized_sites:
       - "{{ outer_item.site }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
   register: __checkmk_var_result_users_create
   loop: "{{ checkmk_var_users_create }}"
   failed_when: not __checkmk_var_result_users_create.changed
@@ -75,8 +69,6 @@
     redirect: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Create same users again."
   user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
@@ -107,8 +99,6 @@
     authorized_sites:
       - "{{ outer_item.site }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
   register: __checkmk_var_result_users_recreate
   loop: "{{ checkmk_var_users_create }}"
   failed_when: __checkmk_var_result_users_recreate.changed
@@ -137,8 +127,6 @@
     show_mode: "{{ item.show_mode | default(omit) }}"
     roles: "{{ item.roles | default(omit) }}"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   loop: "{{ checkmk_var_users_edit }}"
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Don't edit auth user."
@@ -151,8 +139,6 @@
     name: "{{ checkmk_var_api_user }}"
     show_mode: "enforce_show_more"
     state: "present"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   register: __checkmk_var_result_dont_edit
   failed_when: "'You cannot modify the user that is used for API' not in __checkmk_var_result_dont_edit.msg"
 
@@ -166,8 +152,6 @@
     redirect: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Change PW of users."
   user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
@@ -180,8 +164,6 @@
     password: "{{ item.password }}"
     auth_type: "{{ item.auth_type }}"
     state: "reset_password"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
   register: __checkmk_var_result_users_pw_change
   loop: "{{ checkmk_var_users_newpw }}"
   failed_when: not __checkmk_var_result_users_pw_change.changed
@@ -196,8 +178,6 @@
     redirect: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
 
 # This test ensures, that the parameter 'mega_menu_icons' works up until Checkmk 2.5.0,
 # as the name was changed in 2.5.0, but an alias still allows the old name.
@@ -238,8 +218,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
   register: __checkmk_var_result_users_delete
   loop: "{{ checkmk_var_users_create }}"
   failed_when: not __checkmk_var_result_users_delete.changed
@@ -254,8 +232,6 @@
     redirect: true
     sites:
       - "{{ outer_item.site }}"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
 
 - name: "{{ outer_item.version }} - {{ outer_item.edition | upper }} - Delete same users again."
   user: # noqa fqcn[action-core] # The FQCN lint makes no sense here, as we want to test our local module
@@ -265,8 +241,6 @@
     api_secret: "{{ checkmk_var_api_secret }}"
     name: "{{ item.name }}"
     state: "absent"
-  delegate_to: localhost
-  run_once: true # noqa run-once[task]
   register: __checkmk_var_result_users_redelete
   loop: "{{ checkmk_var_users_create }}"
   failed_when: __checkmk_var_result_users_redelete.changed
@@ -276,6 +250,4 @@
     name: "{{ item.name }}"
     state: "absent"
   loop: "{{ checkmk_var_users_create }}"
-  delegate_to: localhost
-  run_once: true  # noqa run-once[task]
   environment: "{{ __checkmk_var_testing_environment }}"


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Historically, some `delegate_to: localhost` and `run_once: true` were carried over from different testing approaches to the current testing regiment.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

As these options make no sense in the current testing regiment, they are removed.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
