### PR TITLE
LDAP module: Now compatible with Checkmk 2.5.0

### DIFF
--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -16,6 +16,7 @@ EXTEND_STATE = {
     "member_attribute": "attribute",
     "authentication_expiration": "attribute_to_sync",
     "disable_notifications": "attribute_to_sync",
+    "main_menu_icons": "attribute_to_sync",
     "mega_menu_icons": "attribute_to_sync",
     "navigation_bar_icons": "attribute_to_sync",
     "pager": "attribute_to_sync",

--- a/plugins/modules/ldap.py
+++ b/plugins/modules/ldap.py
@@ -322,6 +322,7 @@ options:
                             - time you can zoom in more quickly to a specific entry.
                         type: str
                         default: ""
+                        aliases: ["main_menu_icons"]
                     navigation_bar_icons:
                         description:
                             - With this option enabled you can define if icons in the navigation
@@ -680,6 +681,9 @@ from ansible_collections.checkmk.general.plugins.module_utils.utils import (
     base_argument_spec,
     exit_module,
 )
+from ansible_collections.checkmk.general.plugins.module_utils.version import (
+    CheckmkVersion,
+)
 
 logger = Logger()
 
@@ -724,6 +728,7 @@ class LDAPAPI(CheckmkAPI):
         super().__init__(module)
 
         self.desired_state = self.params.get("state")
+        self.version = self.getversion()
 
         error = self._verify_basic_parameters()
         if error:
@@ -748,10 +753,34 @@ class LDAPAPI(CheckmkAPI):
 
         self.desired = self.ldap_config.copy()
         if self.desired_state == "present":
+            self.desired = self._ensure_version_compatibility(self.desired)
             self.desired = self._set_defaults(self.desired)
             self.desired = self._extend_state_parameters(self.desired)
 
         self.differ = ConfigDiffer(self.desired, self.current)
+
+    def _ensure_version_compatibility(self, ldap_config):
+        """
+        Handle incompatibilities between Checkmk versions
+        """
+        sync_plugins = ldap_config.get("sync_plugins", {})
+        mmi = sync_plugins.get("main_menu_icons", sync_plugins.get("mega_menu_icons"))
+
+        if mmi is None:
+            return ldap_config
+
+        if self.version < CheckmkVersion("2.5.0"):
+            # remove main_menu_icons if present and replyce with mega_menu_icons
+            if "main_menu_icons" in sync_plugins:
+                del ldap_config["sync_plugins"]["main_menu_icons"]
+                ldap_config["sync_plugins"]["mega_menu_icons"] = mmi
+        else:
+            # remove main_menu_icons if present and replyce with mega_menu_icons
+            if "mega_menu_icons" in sync_plugins:
+                del ldap_config["sync_plugins"]["mega_menu_icons"]
+                ldap_config["sync_plugins"]["main_menu_icons"] = mmi
+
+        return ldap_config
 
     def _set_defaults(self, ldap_config):
         """
@@ -859,7 +888,9 @@ class LDAPAPI(CheckmkAPI):
             self.headers["If-Match"] = result.etag.replace('"', "")
             try:
                 current_raw = json.loads(result.content)
-                self.current = current_raw.get("extensions", {})
+                self.current = self._ensure_version_compatibility(
+                    current_raw.get("extensions", {})
+                )
                 self.current["id"] = current_raw.get("id")
 
             except json.JSONDecodeError:
@@ -1157,7 +1188,9 @@ def run_module():
                         "authentication_expiration": dict(type="str", default=""),
                         "disable_notifications": dict(type="str", default=""),
                         "email_address": dict(type="str", default=""),
-                        "mega_menu_icons": dict(type="str", default=""),
+                        "mega_menu_icons": dict(
+                            type="str", default="", aliases=["main_menu_icons"]
+                        ),
                         "navigation_bar_icons": dict(type="str", default=""),
                         "pager": dict(type="str", default=""),
                         "show_mode": dict(type="str", default=""),


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?

The LDAP module wasn't able to handle the user parameter "main_menu_icons" that was named "mega_menu_icons" in versions older than 2.5.0.

## What is the new behavior?

- The LDAP module is now correctly handling the new parameter and allows the usage of the old name as an alias.

## Other information
