### PR TITLE
Fix new host change not always activated

### DIFF
--- a/roles/agent/tasks/Linux.yml
+++ b/roles/agent/tasks/Linux.yml
@@ -79,13 +79,15 @@
     attributes: "{{ checkmk_agent_host_attributes }}"
     state: "present"
   become: false
-  register: __checkmk_agent_create_result
+  register: __checkmk_agent_update_attributes_result
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   when: checkmk_agent_add_host | bool
   notify: "Activate changes"
 
 - name: "Ensure registration readyness."  # noqa no-handler
-  when: __checkmk_agent_create_result.changed | bool
+  when:
+    - (__checkmk_agent_create_result.changed | bool) or
+      (__checkmk_agent_update_attributes_result.changed | bool)
   block:
     - name: "Trigger activation of changes."
       ansible.builtin.meta: flush_handlers

--- a/roles/agent/tasks/Win32NT.yml
+++ b/roles/agent/tasks/Win32NT.yml
@@ -32,13 +32,15 @@
     attributes: "{{ checkmk_agent_host_attributes }}"
     state: "present"
   become: false
-  register: __checkmk_agent_create_result
+  register: __checkmk_agent_update_attributes_result
   delegate_to: "{{ checkmk_agent_delegate_api_calls }}"
   when: checkmk_agent_add_host | bool
   notify: "Activate changes"
 
 - name: "Ensure registration readyness."  # noqa no-handler
-  when: __checkmk_agent_create_result.changed | bool
+  when:
+    - (__checkmk_agent_create_result.changed | bool) or
+      (__checkmk_agent_update_attributes_result.changed | bool)
   block:
     - name: "Trigger activation of changes."
       ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
In cases where a host is created but no attributes are set one task would overwrite the variable used for registering task output from the other task. This would also overwrite the changed boolean, which results in the new host change not being activated in the checkmk server. This in turn results in other tasks failing further down the line.

This change introduced separate variables for these two tasks, and then checks if either of them is true, and if so, proceeds to activate the changes in the checkmk server.

Fixes #1042

> Provide a brief summary of your changes as a title in the textbox above
>
> Use the devel branch as the merge target (see dropdown above)!
> We use that branch as a staging area, to make sure the main branch
> stays as stable as possible, in case people are using it to install the collection directly.

## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #1042 

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- The changes are activated.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.

N.A.