### PR TITLE
Make the `discovery` module ready for Checkmk 3.0

### DIFF
--- a/changelogs/fragments/discovery.yml
+++ b/changelogs/fragments/discovery.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Discovery module - Add support for Checkmk 3.0.

--- a/plugins/module_utils/discovery_300.py
+++ b/plugins/module_utils/discovery_300.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+
+# Copyright: (c) 2022 - 2025,
+#   Michael Sekania &
+#   Robin Gierse <robin.gierse@checkmk.com> &
+#   Max Sickora <max.sickora@checkmk.com> &
+#   Lars Getwan <lars.getwan@checkmk.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import time
+
+from ansible_collections.checkmk.general.plugins.module_utils.api import CheckmkAPI
+from ansible_collections.checkmk.general.plugins.module_utils.discovery import (
+    HTTP_CODES,
+    HTTP_CODES_BULK,
+    HTTP_CODES_BULK_SC,
+    HTTP_CODES_SC,
+    Discovery,
+)
+from ansible_collections.checkmk.general.plugins.module_utils.types import (
+    generate_result,
+)
+
+COMPATIBLE_MODES = [
+    "new",
+    "remove",
+    "fix_all",
+    "only_host_labels",
+    "only_service_labels",
+    "tabula_rasa",
+    "refresh",
+    "monitor_undecided_services",
+]
+
+MONITOR_UNDECIDED_SERVICES = [
+    "new",
+    "fix_all",
+    "refresh",
+    "tabula_rasa",
+    "monitor_undecided_services",
+]
+
+REMOVE_VANISHED_SERVICES = ["remove", "fix_all", "refresh", "tabula_rasa"]
+
+UPDATE_SERVICE_LABELS = [
+    "only_service_labels",
+    "fix_all",
+    "refresh",
+    "tabula_rasa",
+]
+
+UPDATE_HOST_LABELS = [
+    "new",
+    "fix_all",
+    "only_host_labels",
+    "refresh",
+    "tabula_rasa",
+]
+
+SUPPORTED_VERSIONS = {
+    "min": "2.6.0",
+    "max": "3.0.0p99",
+}
+
+
+class ServiceDiscoveryAPI(CheckmkAPI):
+    def post(self):
+        mode = self.params.get("state")
+        if mode not in COMPATIBLE_MODES:
+            return generate_result(
+                msg="State %s is not supported with this Checkmk version." % mode
+            )
+
+        if mode == "monitor_undecided_services":
+            return generate_result(
+                msg="State %s is only supported in bulk mode." % mode
+            )
+
+        data = {
+            "host_name": self.params.get("host_name"),
+            "mode": mode,
+        }
+
+        return self._fetch(
+            code_mapping=HTTP_CODES,
+            endpoint="domain-types/service_discovery_run/actions/start/invoke",
+            data=data,
+            method="POST",
+            logger=self.logger,
+        )
+
+
+class ServiceBulkDiscoveryAPI(CheckmkAPI):
+    def post(self):
+        mode = self.params.get("state")
+        if mode not in COMPATIBLE_MODES:
+            return generate_result(
+                msg="State %s is not supported with this Checkmk version." % mode
+            )
+
+        options = {
+            "monitor_undecided_services": False,
+            "remove_vanished_services": False,
+            "update_service_labels": False,
+            "update_host_labels": False,
+        }
+
+        if self.params.get("state") in MONITOR_UNDECIDED_SERVICES:
+            options["monitor_undecided_services"] = True
+
+        if self.params.get("state") in REMOVE_VANISHED_SERVICES:
+            options["remove_vanished_services"] = True
+
+        if self.params.get("state") in UPDATE_SERVICE_LABELS:
+            options["update_service_labels"] = True
+
+        if self.params.get("state") in UPDATE_HOST_LABELS:
+            options["update_host_labels"] = True
+
+        data = {
+            "hostnames": self.params.get("hosts", []),
+            "options": options,
+            "do_full_scan": self.params.get("do_full_scan", True),
+            "bulk_size": self.params.get("bulk_size", 1),
+            "ignore_errors": self.params.get("ignore_errors", True),
+        }
+
+        return self._fetch(
+            code_mapping=HTTP_CODES_BULK,
+            endpoint="domain-types/discovery_run/actions/bulk-discovery-start/invoke",
+            data=data,
+            method="POST",
+        )
+
+
+class ServiceCompletionAPI(CheckmkAPI):
+    def get(self):
+        data = {}
+
+        return self._fetch(
+            code_mapping=HTTP_CODES_SC,
+            endpoint=(
+                "objects/service_discovery_run/"
+                + self.params.get("host_name")
+                + "/actions/wait-for-completion/invoke"
+            ),
+            data=data,
+            method="GET",
+        )
+
+
+class ServiceCompletionBulkAPI(CheckmkAPI):
+    def get(self, job_id):
+        data = {}
+
+        return self._fetch(
+            code_mapping=HTTP_CODES_BULK_SC,
+            endpoint=("objects/background_job/%s" % job_id),
+            data=data,
+            method="GET",
+        )
+
+
+class Discovery300(Discovery):
+    def __init__(self, module, logger):
+        super().__init__(module, logger)
+
+        self.discovery_single = ServiceDiscoveryAPI(self.module, self.logger)
+        self.discovery_bulk = ServiceBulkDiscoveryAPI(self.module, self.logger)
+        self.completion_single = ServiceCompletionAPI(self.module, self.logger)
+        self.completion_bulk = ServiceCompletionBulkAPI(self.module, self.logger)
+
+        self.discovery_api = self._discovery_api()
+        self.service_completion_api = self._service_completion_api()
+
+        self.supported_versions = SUPPORTED_VERSIONS
+
+    def _discovery_api(self):
+        if self.single_mode:
+            return self.discovery_single
+
+        return self.discovery_bulk
+
+    def _service_completion_api(self):
+        if self.single_mode:
+            return self.completion_single
+
+        return self.completion_bulk
+
+    def _wait_for_completion(self, what, job_id=None):
+        now = time.time()
+
+        if self.timeout > 0:
+            deadline = now + self.timeout
+        else:
+            deadline = 0  # In case of infinite timeout
+
+        if self.bulk_mode and not job_id:
+            return generate_result(
+                msg=(
+                    "Unable to get job_id for bulk service discovery. "
+                    "Will not wait for job to finish"
+                ),
+                failed=False,
+                changed=True,
+            )
+
+        while True:
+            now = time.time()
+            if self.timeout > 0 and now > deadline:
+                return generate_result(
+                    msg="Timeout reached while waiting for %s discovery" % what
+                )
+
+            if self.single_mode:
+                result = self.service_completion_api.get()
+                # For single mode, there's a forwarding, but _fetch() doesn't support that.
+                if result.http_code != 302:
+                    break
+
+            else:
+                # For bulk mode, the completion api shows the state of the job
+                result = self.service_completion_api.get(job_id)
+                if not json.loads(result.content).get("extensions").get("active"):
+                    break
+
+            time.sleep(3)
+
+        return result
+
+    def start_discovery(self):
+        if self.wait_for_previous and self.single_mode:
+            # For bulk mode, it's neither possible nor necessary to wait for the previous
+            # discovery, as jobs are now allowed to run in parallel
+            result = self._wait_for_completion("previous")
+            if result.failed:
+                return result
+
+        result = self.discovery_api.post()
+        if result.failed:
+            return result
+
+        if self.wait_for_completion:
+            if self.single_mode and result.http_code != 200:
+                result = self._wait_for_completion("current")
+            elif self.bulk_mode:
+                job_id = json.loads(result.content).get("id")
+                result = self._wait_for_completion("current", job_id=job_id)
+
+        return result

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -275,6 +275,9 @@ from ansible_collections.checkmk.general.plugins.module_utils.discovery_240 impo
 from ansible_collections.checkmk.general.plugins.module_utils.discovery_250 import (
     Discovery250,
 )
+from ansible_collections.checkmk.general.plugins.module_utils.discovery_300 import (
+    Discovery300,
+)
 from ansible_collections.checkmk.general.plugins.module_utils.logger import Logger
 from ansible_collections.checkmk.general.plugins.module_utils.types import (
     generate_result,
@@ -288,6 +291,7 @@ logger = Logger()
 
 AVAILABLE_API_VERSIONS = [
     # Let's try the newest Version, first.
+    Discovery300,
     Discovery250,
     Discovery240,
     Discovery230,

--- a/tests/integration/targets/discovery/tasks/test.yml
+++ b/tests/integration/targets/discovery/tasks/test.yml
@@ -70,7 +70,7 @@
       loop: "{{ checkmk_var_hosts }}"
       register: __checkmk_var_result_labels
       failed_when: "'State only_service_labels is not supported with this Checkmk version' not in __checkmk_var_result_labels.msg"
-      when: "not '2.3.0' in outer_item.version and not '2.4.0' in outer_item.version and not '2.5.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '<')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Monitor undecided services. (Should fail < 2.3.0)"
       discovery:
@@ -83,7 +83,7 @@
       loop: "{{ checkmk_var_hosts }}"
       register: __checkmk_var_result_undecided_pre_23
       failed_when: "'State monitor_undecided_services is not supported with this Checkmk version' not in __checkmk_var_result_undecided_pre_23.msg"
-      when: "not '2.3.0' in outer_item.version and not '2.4.0' in outer_item.version and not '2.5.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '<')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Update service labels."
       discovery:
@@ -94,7 +94,7 @@
         host_name: "{{ item.name }}"
         state: "only_service_labels"
       loop: "{{ checkmk_var_hosts }}"
-      when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '>=')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Monitor undecided services. (Should fail in 2.3.0 and above)"
       discovery:
@@ -107,7 +107,7 @@
       loop: "{{ checkmk_var_hosts }}"
       register: __checkmk_var_result_undecided_post_23
       failed_when: "'State monitor_undecided_services is only supported in bulk mode.' not in __checkmk_var_result_undecided_post_23.msg"
-      when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '>=')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Tabula Rasa. (New since 2.2)"
       discovery:
@@ -118,7 +118,7 @@
         host_name: "{{ item.name }}"
         state: "tabula_rasa"
       loop: "{{ checkmk_var_hosts }}"
-      when: "not '2.1' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.2.0', '>=')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Discover hosts (fix_all)."
       discovery:
@@ -161,7 +161,7 @@
       - "{{ outer_item.site }}"
 
 - name: "Run Bulk Discoveries."
-  when: "not '2.0.0' in outer_item.version"
+  when: "(outer_item.version | regex_replace('p.*', '')) is version('2.1.0', '>=')"
   block:
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create hosts."
       host:
@@ -218,7 +218,7 @@
         bulk_size: 5
       register: __checkmk_var_result_labels_pre_23
       failed_when: "'State only_service_labels is not supported with this Checkmk version.' not in __checkmk_var_result_labels_pre_23.msg"
-      when: "not '2.3.0' in outer_item.version and not '2.4.0' in outer_item.version and not '2.5.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '<')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Bulk: Monitor undecided services. (Should fail < 2.3.0)"
       discovery:
@@ -231,9 +231,9 @@
         bulk_size: 5
       register: __checkmk_var_result_labels_post_23
       failed_when: "'State monitor_undecided_services is not supported with this Checkmk version.' not in __checkmk_var_result_labels_post_23.msg"
-      when: "not '2.3.0' in outer_item.version and not '2.4.0' in outer_item.version and not '2.5.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '<')"
 
-    - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Bulk: Update service labels. (only 2.3)"
+    - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Bulk: Update service labels. (2.3+)"
       discovery:
         server_url: "{{ checkmk_var_server_url }}"
         site: "{{ outer_item.site }}"
@@ -242,9 +242,9 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "only_service_labels"
         bulk_size: 5
-      when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '>=')"
 
-    - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Bulk: Monitor undecided services. (only 2.3)"
+    - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Bulk: Monitor undecided services. (2.3+)"
       discovery:
         server_url: "{{ checkmk_var_server_url }}"
         site: "{{ outer_item.site }}"
@@ -253,7 +253,7 @@
         hosts: "{{ checkmk_var_host_names }}"
         state: "monitor_undecided_services"
         bulk_size: 5
-      when: "'2.3.0' in outer_item.version or '2.4.0' in outer_item.version"
+      when: "(outer_item.version | regex_replace('p.*', '')) is version('2.3.0', '>=')"
 
     - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Bulk: Add undecided services to monitoring."
       discovery:


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Enable the `discovery` module to interact with the upconfing Checkmk 2.6.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

The `discovery` module fails, when running against Checkmk 3.0

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

The module now supports the upcoming Checkmk 3.0.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
