### PR TITLE
Enable cleaner server role output and fix secret masking

### DIFF
--- a/changelogs/fragments/server.yml
+++ b/changelogs/fragments/server.yml
@@ -4,6 +4,14 @@ minor_changes:
     ``omd_config`` defined was started first, only to be stopped again
     immediately to apply the configuration. Now the configuration is applied
     while the site is still stopped and the site is started only once.
+  - Server role - Use the site or package name as the loop label in the site
+    and MKP management tasks for cleaner output. The ``no_log`` logic was
+    also improved to be as little obstructive as possible.
 bugfixes:
   - Server role - Only update the site admin password when it actually
     differs from the configured one.
+security_fixes:
+  - Server role - The MKP management tasks no longer show the whole package
+    dictionary, including a potentially configured ``download_password``,
+    as the loop label. Additionally, the MKP download task now honors
+    ``checkmk_server_no_log`` when a ``download_password`` is configured.

--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -158,7 +158,7 @@ Extension packages can also be listed to be installed on the specific central si
 
     checkmk_server_no_log: true
 
-Whether to log sensitive information like passwords. Ansible output will be censored for enhanced security by default. Set to `false` for easier troubleshooting.
+Whether to log sensitive information like passwords. Ansible output will be censored for enhanced security by default. Censoring is applied per item: only tasks and loop items that handle sensitive data, like sites with an `admin_pw` or packages with a `download_password`, are censored. Set to `false` to disable censoring altogether for easier troubleshooting.
 > **Warning**: Be careful when changing this value in production, passwords may be leaked in operating system logs.
 
     checkmk_server_configure_firewall: true

--- a/roles/server/meta/argument_specs.yml
+++ b/roles/server/meta/argument_specs.yml
@@ -94,6 +94,7 @@ argument_specs:
             options:
               name:
                 type: "str"
+                required: true
                 description: "The name of the extension package."
               version:
                 type: "str"

--- a/roles/server/tasks/mkp.yml
+++ b/roles/server/tasks/mkp.yml
@@ -14,6 +14,7 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   when: __mkp.url is defined
   tags:
     - manage-mkp-packages
@@ -29,6 +30,7 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   when: __mkp.src is defined
   tags:
     - manage-mkp-packages
@@ -43,6 +45,7 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   when: (__mkp.installed | default(true) ) | bool
   tags:
     - manage-mkp-packages
@@ -56,6 +59,7 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   when: (__mkp.enabled | default(true)) | bool
   tags:
     - manage-mkp-packages
@@ -69,6 +73,7 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   when: __mkp.enabled is defined and (not __mkp.enabled | bool)
   tags:
     - manage-mkp-packages
@@ -82,6 +87,7 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   when: __mkp.installed is defined and (not __mkp.installed | bool)
   tags:
     - manage-mkp-packages
@@ -94,5 +100,6 @@
   loop: "{{ __site.mkp_packages }}"
   loop_control:
     loop_var: __mkp
+    label: "{{ __mkp.name }}"
   tags:
     - manage-mkp-packages

--- a/roles/server/tasks/mkp.yml
+++ b/roles/server/tasks/mkp.yml
@@ -10,6 +10,7 @@
     url_username: "{{ __mkp.download_user | default(omit) }}"
     url_password: "{{ __mkp.download_password | default(omit) }}"
     checksum: "{{ __mkp.checksum | default(omit) }}"
+  no_log: "{{ __mkp.download_password is defined and checkmk_server_no_log | bool }}"
   retries: 3
   loop: "{{ __site.mkp_packages }}"
   loop_control:

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -13,7 +13,7 @@
   args:
     executable: /bin/bash
     creates: "/omd/sites/{{ item.name }}"
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -35,7 +35,7 @@
     omd version {{ item.name }} | egrep -o '[^ ]+$'
   args:
     executable: /bin/bash
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -66,7 +66,7 @@
     fi
   args:
     executable: /bin/bash
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -80,7 +80,7 @@
   ansible.builtin.include_tasks: configure-site.yml
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ outer_item | combine({'admin_pw': omit}) }}"
+    label: "{{ outer_item.name }}"
     loop_var: outer_item
   when: |
     outer_item.omd_config is defined and
@@ -97,7 +97,7 @@
   args:
     executable: /bin/bash
     creates: "/opt/omd/sites/{{ item.name }}/tmp/run/live"
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -114,7 +114,7 @@
   args:
     executable: /bin/bash
     removes: "/opt/omd/sites/{{ item.name }}/tmp/run/live"
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -134,7 +134,7 @@
     fi
   args:
     executable: /bin/bash
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -152,7 +152,7 @@
   args:
     executable: /bin/bash
     removes: "/omd/sites/{{ item.name }}"
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.admin_pw is defined and checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
     label: "{{ item.name }}"
@@ -223,6 +223,6 @@
   when: __checkmk_server_sites_created.changed | bool and not item.item.admin_pw is defined and item.item.state != "absent"
   changed_when: true
   notify: Warn site admin password
-  no_log: "{{ checkmk_server_no_log | bool }}"
+  no_log: "{{ item.item.admin_pw is defined and checkmk_server_no_log | bool }}"
   tags:
     - create-sites

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -16,7 +16,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: item.state != "absent"
   register: __checkmk_server_sites_created
   tags:
@@ -38,7 +38,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   changed_when: "__checkmk_server_sites_versions.stdout != item.version + '.' + __checkmk_var_edition_id | lower"
   when: item.state != "absent"
   register: __checkmk_server_sites_versions
@@ -49,7 +49,7 @@
   ansible.builtin.include_tasks: update-site.yml
   loop: "{{ __checkmk_server_sites_versions.results }}"
   loop_control:
-    label: "{{ item | ansible.utils.remove_keys(target=['admin_pw']) }}"
+    label: "{{ item.item.name }}"
   when: "item.changed"
   tags:
     - update-sites
@@ -69,7 +69,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: (item.state == "enabled") or (item.state == "started")
   register: __checkmk_server_sites_stopped
   changed_when: "'Autostart enabled.' in __checkmk_server_sites_stopped.stdout"
@@ -100,7 +100,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: item.state == "started"
   register: __checkmk_server_sites_started
   tags:
@@ -117,7 +117,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: item.state != "started"
   register: __checkmk_server_sites_stopped
   tags:
@@ -137,7 +137,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: (item.state == "disabled") or (item.state == "present") or (item.state == "stopped")
   register: __checkmk_server_sites_stopped
   changed_when: "'Autostart disabled.' in __checkmk_server_sites_stopped.stdout"
@@ -155,7 +155,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: item.state == "absent"
   register: __checkmk_server_sites_removed
   tags:
@@ -165,7 +165,7 @@
   ansible.builtin.include_tasks: mkp.yml
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ __site | combine({'admin_pw': omit}) }}"
+    label: "{{ __site.name }}"
     loop_var: __site
   when: __site.mkp_packages is defined
 
@@ -183,7 +183,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: item.admin_pw is defined and (item.state != "absent") and (item.version | regex_replace('p.*', '') is version('2.1', '<'))
   register: __checkmk_server_admin_pw_legacy
   changed_when: "'Password updated.' in __checkmk_server_admin_pw_legacy.stdout"
@@ -206,7 +206,7 @@
   no_log: "{{ checkmk_server_no_log | bool }}"
   loop: "{{ checkmk_server_sites }}"
   loop_control:
-    label: "{{ item | combine({'admin_pw': omit}) }}"
+    label: "{{ item.name }}"
   when: item.admin_pw is defined and (item.state != "absent") and (item.version | regex_replace('p.*', '') is version('2.1', '>='))
   register: __checkmk_server_admin_pw
   changed_when: "'Password updated.' in __checkmk_server_admin_pw.stdout"
@@ -219,7 +219,7 @@
       - "Just a trigger."
   loop: "{{ __checkmk_server_sites_created.results }}"
   loop_control:
-    label: "{{ item | ansible.utils.remove_keys(target=['admin_pw']) }}"
+    label: "{{ item.item.name }}"
   when: __checkmk_server_sites_created.changed | bool and not item.item.admin_pw is defined and item.item.state != "absent"
   changed_when: true
   notify: Warn site admin password


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Due to security concerns, a contributor introduced censoring task output, so passwords would not be printed to the terminal or logs. This mechanism made it hard to read the output of some tasks and ultimately was flawed to begin with.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

This PR explores a different way of solving the issue, while producing cleaner task output.
It does so by removing the blacklist approach and actively filtering for the values we want to print (namely the `name` attribute of sites and MKPs).

Additionally, the conditionals involved were improved and gaps were filled, where secrets could have been revealed.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
