### PR TITLE
Bugfix  default auth_type for user module

### DIFF
--- a/changelogs/fragments/user.yml
+++ b/changelogs/fragments/user.yml
@@ -1,0 +1,11 @@
+bugfixes:
+  - User module - Fix editing of users that authenticate via LDAP or SAML.
+    Since 7.1.0, the parameter ``auth_type`` defaulted to ``password``, so every edit
+    of an existing user silently reset LDAP- or SAML-authenticated users to local authentication.
+    The default has been removed and the authentication option is now only changed when
+    ``auth_type``, ``password`` or ``enforce_password_change`` is set explicitly.
+
+breaking_changes:
+  - User module - The parameter ``auth_type`` no longer defaults to ``password``.
+    Playbooks that create a new user and rely on this default must now set ``auth_type`` explicitly.
+    Existing playbooks that already pass ``auth_type`` are unaffected.

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -31,8 +31,10 @@ options:
         description:
             - The authentication type.
               Setting this to C(password) will create a normal user, C(automation) will create an automation user.
+            - When omitted on an existing user, the user's current authentication method
+              (including LDAP or SAML) is preserved. Only specify this when you intend to
+              set or change the user's local authentication.
         required: false
-        default: password
         type: str
         choices: ["password", "automation"]
     authorized_sites:
@@ -414,8 +416,14 @@ class UserAPI(CheckmkAPI):
         user["interface_options"] = {}
 
         # For some keys the API has required sub keys. We can use them as indicator,
-        # that the key must be used
-        if self.required.get("auth_type"):
+        # that the key must be used.
+        # Only build `auth_option` when the user explicitly asked for an auth change;
+        # otherwise editing any unrelated attribute would reset LDAP/SAML users to
+        # local password authentication.
+        if any(
+            self.required.get(k) is not None
+            for k in ("auth_type", "password", "enforce_password_change")
+        ):
             user["auth_option"] = {}
         if self.required.get("email"):
             user["contact_options"] = {}
@@ -589,9 +597,7 @@ def run_module():
         customer=dict(type="str", required=False),
         password=dict(type="str", no_log=True),
         enforce_password_change=dict(type="bool", no_log=False),
-        auth_type=dict(
-            type="str", default="password", choices=["password", "automation"]
-        ),
+        auth_type=dict(type="str", choices=["password", "automation"]),
         disable_login=dict(type="bool"),
         email=dict(type="str"),
         fallback_contact=dict(type="bool"),


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Since 7.1.0, the parameter `auth_type` defaulted to `password`, so every edit of an existing user silently reset LDAP- or SAML-authenticated users to local authentication.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

The default has been removed and the authentication option is now only changed when `auth_type`, `password` or ``enforce_password_change`` is set explicitly.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.

**This is a breaking change and needs a dedicated release.**