### PR TITLE
Fix environment variable support for the inventory plugin

### DIFF
--- a/.github/workflows/ans-unit-test-inventory.yaml
+++ b/.github/workflows/ans-unit-test-inventory.yaml
@@ -17,10 +17,12 @@ on:
       - devel
     paths:
       - 'plugins/inventory/checkmk.py'
+      - 'plugins/doc_fragments/common_lookup.py'
   push:
     paths:
       - '.github/workflows/ans-unit-test-inventory.yaml'
       - 'plugins/inventory/checkmk.py'
+      - 'plugins/doc_fragments/common_lookup.py'
       - 'plugins/module_utils/**'
       - 'tests/unit/plugins/module_utils/**'
       - 'tests/unit/plugins/inventory/**'
@@ -31,4 +33,4 @@ jobs:
     name: "Tests"
     uses: ./.github/workflows/_template-ans-unit-test.yaml
     with:
-      testpath: tests/unit/plugins/inventory/test_checkmk.py
+      testpath: tests/unit/plugins/inventory/

--- a/changelogs/fragments/inventory.yml
+++ b/changelogs/fragments/inventory.yml
@@ -1,0 +1,9 @@
+minor_changes:
+  - Checkmk inventory plugin - Credentials can now be provided via ``CHECKMK_VAR_*``
+    environment variables, ``checkmk_var_*`` Ansible variables, or the
+    ``[checkmk_lookup]`` section in ``ansible.cfg``.
+    Cookie-based authentication is also supported via the new ``api_auth_type``
+    and ``api_auth_cookie`` options.
+  - All modules - Cookie-based authentication can now be used without providing
+    ``api_user`` and ``api_secret``. Bearer and basic authentication still require
+    them.

--- a/plugins/doc_fragments/common.py
+++ b/plugins/doc_fragments/common.py
@@ -31,14 +31,14 @@ class ModuleDocFragment(object):
             description:
                 - The automation user you want to use. It has to be an 'Automation' user, not a normal one.
                   If not set the module will fall back to the environment variable C(CHECKMK_VAR_API_USER).
-            required: true
+            required: false
             type: str
             aliases: [automation_user]
         api_secret:
             description:
                 - The secret to authenticate your automation user.
                   If not set the module will fall back to the environment variable C(CHECKMK_VAR_API_SECRET).
-            required: true
+            required: false
             type: str
             aliases: [automation_secret]
         api_auth_cookie:

--- a/plugins/doc_fragments/common_lookup.py
+++ b/plugins/doc_fragments/common_lookup.py
@@ -84,4 +84,9 @@ class ModuleDocFragment(object):
                   key: validate_certs
             type: bool
             default: True
+      notes:
+        - Connection parameters are resolved from (in order of precedence) the value
+          set directly on the plugin invocation, an Ansible variable of the form
+          C(checkmk_var_*), an environment variable of the form C(CHECKMK_VAR_*),
+          and the matching key under section C([checkmk_lookup]) in C(ansible.cfg).
     """

--- a/plugins/inventory/checkmk.py
+++ b/plugins/inventory/checkmk.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
         - Get hosts from any checkmk site.
         - Generate groups based on tag groups or sites in Checkmk.
 
-    extends_documentation_fragment: [checkmk.general.common]
+    extends_documentation_fragment: [checkmk.general.common_lookup]
 
     options:
         plugin:
@@ -33,6 +33,11 @@ DOCUMENTATION = """
             description: Update ansible_host variable with ip address from Checkmk
             type: boolean
             required: false
+    notes:
+        - Because inventory plugins run before C(group_vars/) and C(host_vars/) are
+          loaded, C(checkmk_var_*) values placed there are B(not) visible to this
+          plugin. Sources that B(do) work are extra-vars (C(-e)), environment
+          variables (C(CHECKMK_VAR_*)) and C(ansible.cfg) C([checkmk_lookup]) entries.
 """
 
 EXAMPLES = """
@@ -49,6 +54,30 @@ api_secret: "******"
 validate_certs: false
 groupsources: ["hosttags", "sites"]
 want_ipv4: False
+
+# ---------------------------------------------------------------------------
+# Using environment variables for credentials
+# ---------------------------------------------------------------------------
+# Connection parameters can be provided via environment variables instead of
+# writing them into the inventory file. The supported variables are:
+#   CHECKMK_VAR_SERVER_URL, CHECKMK_VAR_SITE,
+#   CHECKMK_VAR_API_USER, CHECKMK_VAR_API_SECRET,
+#   CHECKMK_VAR_VALIDATE_CERTS, CHECKMK_VAR_API_AUTH_TYPE
+
+# Minimal inventory file when using environment variables:
+plugin: checkmk.general.checkmk
+groupsources: ["hosttags", "sites"]
+
+# ---------------------------------------------------------------------------
+# Using Ansible variables for credentials
+# ---------------------------------------------------------------------------
+# Connection parameters can also be provided via Ansible variables, e.g.
+# via extra-vars (`-e`). Note that vars from group_vars/ or host_vars/
+# are NOT visible here, because inventory plugins run before those are loaded.
+# The supported variable names follow the scheme checkmk_var_<parameter>:
+#   checkmk_var_server_url, checkmk_var_site,
+#   checkmk_var_api_user, checkmk_var_api_secret,
+#   checkmk_var_validate_certs, checkmk_var_api_auth_type
 """
 
 import json
@@ -77,6 +106,8 @@ class InventoryModule(BaseInventoryPlugin):
         self.site = None
         self.user = None
         self.secret = None
+        self.api_auth_type = None
+        self.api_auth_cookie = None
         self.validate_certs = None
         self.want_ipv4 = None
         self.groupsources = []
@@ -146,6 +177,8 @@ class InventoryModule(BaseInventoryPlugin):
             self.site = self.get_option("site")
             self.user = self.get_option("api_user")
             self.secret = self.get_option("api_secret")
+            self.api_auth_type = self.get_option("api_auth_type")
+            self.api_auth_cookie = self.get_option("api_auth_cookie")
             self.validate_certs = self.get_option("validate_certs")
             self.want_ipv4 = self.get_option("want_ipv4")
             self.groupsources = self.get_option("groupsources")
@@ -154,6 +187,8 @@ class InventoryModule(BaseInventoryPlugin):
 
         api = CheckMKLookupAPI(
             site_url=self.get_option("server_url") + "/" + self.get_option("site"),
+            api_auth_type=self.api_auth_type,
+            api_auth_cookie=self.api_auth_cookie,
             api_user=self.get_option("api_user"),
             api_secret=self.get_option("api_secret"),
             validate_certs=self.get_option("validate_certs"),

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -32,13 +32,13 @@ def base_argument_spec():
         ),
         api_user=dict(
             type="str",
-            required=True,
+            required=False,
             aliases=["automation_user"],
             fallback=(env_fallback, ["CHECKMK_VAR_API_USER"]),
         ),
         api_secret=dict(
             type="str",
-            required=True,
+            required=False,
             no_log=True,
             aliases=["automation_secret"],
             fallback=(env_fallback, ["CHECKMK_VAR_API_SECRET"]),

--- a/tests/unit/plugins/inventory/test_option_resolution.py
+++ b/tests/unit/plugins/inventory/test_option_resolution.py
@@ -1,0 +1,175 @@
+# Copyright: (c) 2026, Robin Gierse <robin.gierse@checkmk.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from ansible.inventory.data import InventoryData
+from ansible.plugins.loader import inventory_loader
+
+# Minimal required options that are not under test in a given case.
+_REQUIRED = {
+    "plugin": "checkmk.general.checkmk",
+    "server_url": "http://dummy/",
+    "site": "dummy",
+}
+
+
+@pytest.fixture
+def plugin():
+    """Return a properly initialized InventoryModule instance.
+
+    Using inventory_loader.get() (not direct class instantiation) is required so
+    that Ansible's _load_config_defs() is called on the class.  Without it,
+    set_options() has no option definitions and env: / vars: entries are ignored.
+    """
+    plugin_cls = inventory_loader.get("checkmk.general.checkmk", class_only=True)
+    p = plugin_cls()
+    p.inventory = InventoryData()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Environment variable resolution  (CHECKMK_VAR_*)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarResolution:
+    """CHECKMK_VAR_* environment variables must be picked up by get_option()."""
+
+    def test_server_url(self, plugin, monkeypatch):
+        monkeypatch.setenv("CHECKMK_VAR_SERVER_URL", "http://envserver/")
+        monkeypatch.setenv("CHECKMK_VAR_SITE", "envsite")  # also required
+        plugin.set_options(direct={"plugin": "checkmk.general.checkmk"})
+        assert plugin.get_option("server_url") == "http://envserver/"
+
+    def test_site(self, plugin, monkeypatch):
+        monkeypatch.setenv(
+            "CHECKMK_VAR_SERVER_URL", "http://envserver/"
+        )  # also required
+        monkeypatch.setenv("CHECKMK_VAR_SITE", "envsite")
+        plugin.set_options(direct={"plugin": "checkmk.general.checkmk"})
+        assert plugin.get_option("site") == "envsite"
+
+    def test_api_user(self, plugin, monkeypatch):
+        monkeypatch.setenv("CHECKMK_VAR_API_USER", "envuser")
+        plugin.set_options(direct=dict(_REQUIRED))
+        assert plugin.get_option("api_user") == "envuser"
+
+    def test_api_secret(self, plugin, monkeypatch):
+        monkeypatch.setenv("CHECKMK_VAR_API_SECRET", "envsecret")
+        plugin.set_options(direct=dict(_REQUIRED))
+        assert plugin.get_option("api_secret") == "envsecret"
+
+    def test_validate_certs_false(self, plugin, monkeypatch):
+        monkeypatch.setenv("CHECKMK_VAR_VALIDATE_CERTS", "false")
+        plugin.set_options(direct=dict(_REQUIRED))
+        assert plugin.get_option("validate_certs") is False
+
+    def test_api_auth_type(self, plugin, monkeypatch):
+        monkeypatch.setenv("CHECKMK_VAR_API_AUTH_TYPE", "basic")
+        plugin.set_options(direct=dict(_REQUIRED))
+        assert plugin.get_option("api_auth_type") == "basic"
+
+    def test_direct_overrides_env(self, plugin, monkeypatch):
+        """A value given directly in the inventory file beats an env var."""
+        monkeypatch.setenv("CHECKMK_VAR_API_USER", "envuser")
+        plugin.set_options(direct=dict(_REQUIRED, api_user="directuser"))
+        assert plugin.get_option("api_user") == "directuser"
+
+
+# ---------------------------------------------------------------------------
+# Ansible variable resolution  (checkmk_var_*)
+# ---------------------------------------------------------------------------
+
+
+class TestAnsibleVarResolution:
+    """checkmk_var_* Ansible variables must be picked up by get_option().
+
+    This covers credential injection where credentials arrive as host/group vars
+    at runtime rather than being written into the inventory file.
+    """
+
+    def test_server_url(self, plugin):
+        plugin.set_options(
+            var_options={
+                "checkmk_var_server_url": "http://varserver/",
+                "checkmk_var_site": "varsite",
+            },
+            direct={"plugin": "checkmk.general.checkmk"},
+        )
+        assert plugin.get_option("server_url") == "http://varserver/"
+
+    def test_site(self, plugin):
+        plugin.set_options(
+            var_options={
+                "checkmk_var_server_url": "http://varserver/",
+                "checkmk_var_site": "varsite",
+            },
+            direct={"plugin": "checkmk.general.checkmk"},
+        )
+        assert plugin.get_option("site") == "varsite"
+
+    def test_api_user(self, plugin):
+        plugin.set_options(
+            var_options={"checkmk_var_api_user": "varuser"},
+            direct=dict(_REQUIRED),
+        )
+        assert plugin.get_option("api_user") == "varuser"
+
+    def test_api_secret(self, plugin):
+        plugin.set_options(
+            var_options={"checkmk_var_api_secret": "varsecret"},
+            direct=dict(_REQUIRED),
+        )
+        assert plugin.get_option("api_secret") == "varsecret"
+
+    def test_direct_overrides_vars(self, plugin):
+        """A value given directly in the inventory file beats an Ansible variable."""
+        plugin.set_options(
+            var_options={"checkmk_var_api_user": "varuser"},
+            direct=dict(_REQUIRED, api_user="directuser"),
+        )
+        assert plugin.get_option("api_user") == "directuser"
+
+    def test_vars_override_env(self, plugin, monkeypatch):
+        """Ansible variables take precedence over environment variables.
+
+        Resolution order: direct > vars > env > ini > default.
+        """
+        monkeypatch.setenv("CHECKMK_VAR_API_USER", "envuser")
+        plugin.set_options(
+            var_options={"checkmk_var_api_user": "varuser"},
+            direct=dict(_REQUIRED),
+        )
+        assert plugin.get_option("api_user") == "varuser"
+
+
+# ---------------------------------------------------------------------------
+# ansible.cfg resolution  ([checkmk_lookup] section)
+# ---------------------------------------------------------------------------
+
+
+class TestIniResolution:
+    """Keys under [checkmk_lookup] in ansible.cfg must be picked up by get_option()."""
+
+    def test_api_user_from_ini(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "ansible.cfg"
+        cfg.write_text("[checkmk_lookup]\napi_user = iniuser\n")
+        monkeypatch.setenv("ANSIBLE_CONFIG", str(cfg))
+
+        # Force Ansible to re-read its config so ANSIBLE_CONFIG takes effect.
+        from ansible.config.manager import ConfigManager
+        import ansible.constants as C
+
+        monkeypatch.setattr(C, "config", ConfigManager())
+
+        # Build the plugin AFTER swapping the config manager so its option
+        # definitions resolve against the new manager.
+        plugin_cls = inventory_loader.get("checkmk.general.checkmk", class_only=True)
+        p = plugin_cls()
+        p.inventory = InventoryData()
+        p.set_options(direct=dict(_REQUIRED))
+        assert p.get_option("api_user") == "iniuser"


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #1090 

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Inventory plugin credentials can be sourced from `CHECKMK_VAR_*` env vars, `checkmk_var_*` Ansible variables, or the `[checkmk_lookup]` section in `ansible.cfg`.
- Cookie-based authentication is supported on the inventory plugin and on modules, without requiring `api_user`/`api_secret`.
- Add unit tests for the variable resolution (direct / vars / env / ini precedence).

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
