### PR TITLE
Fix password module to be compatible with Checkmk 3.0.0

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -82,6 +82,7 @@ class CheckmkAPI:
         self.required = {}
         # may be "present", "absent" or an individual one
         self.state = ""
+        self.version = None
 
     def _fetch(
         self, code_mapping="", endpoint="", data=None, method="GET", logger=None
@@ -167,6 +168,9 @@ class CheckmkAPI:
         return result
 
     def getversion(self):
+        if self.version:
+            return self.version
+
         data = {}
 
         result = self._fetch(
@@ -181,4 +185,6 @@ class CheckmkAPI:
 
         content = result.content
         checkmkinfo = json.loads(content)
-        return CheckmkVersion(checkmkinfo.get("versions").get("checkmk"))
+        self.version = CheckmkVersion(checkmkinfo.get("versions").get("checkmk"))
+
+        return self.version

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -44,10 +44,10 @@ class CheckmkVersion:
         }
 
         g = self._matchgroups
-        value = (10000 * int(g[0])) + (1000 * int(g[1])) + (100 * int(g[2]))
+        value = (100000 * int(g[0])) + (10000 * int(g[1])) + (1000 * int(g[2]))
 
         if g[3]:
-            value += 10 * patchtype2num[g[3]]
+            value += 100 * patchtype2num[g[3]]
             value += int(g[4])
 
         return value

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -18,7 +18,7 @@ class CheckmkVersion:
 
     def __init__(self, version_raw):
         def _parse(version_raw):
-            _pattern = "([0-9])\\.([0-9])\\.([0-9])([abp])*([0-9]+)*\\.?([a-zA-Z]+)?"
+            _pattern = "([0-9])\\.([0-9])\\.([0-9])([abpi])*([0-9]+)*\\.?([a-zA-Z]+)?"
             r = re.match(_pattern, version_raw)
             return r
 

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -296,10 +296,10 @@ def run_module():
         changed=False,
     )
 
-    passwordget = PasswordsGetAPI(module, logger=logger)
-    checkmkversion = CheckmkVersion(str(passwordget.getversion()))
-
     if module.params.get("state") == "present":
+        passwordget = PasswordsGetAPI(module, logger=logger)
+        checkmkversion = CheckmkVersion(str(passwordget.getversion()))
+
         result = passwordget.get()
 
         if result.http_code == 200:

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -168,14 +168,18 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.checkmk.general.plugins.module_utils.api import CheckmkAPI
+from ansible_collections.checkmk.general.plugins.module_utils.logger import Logger
 from ansible_collections.checkmk.general.plugins.module_utils.types import RESULT
 from ansible_collections.checkmk.general.plugins.module_utils.utils import (
     base_argument_spec,
+    exit_module,
     result_as_dict,
 )
 from ansible_collections.checkmk.general.plugins.module_utils.version import (
     CheckmkVersion,
 )
+
+logger = Logger()
 
 # We count 404 not as failed, because we want to know if the password exists or not.
 HTTP_CODES_GET = {
@@ -269,6 +273,7 @@ def run_module():
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
 
+    logger.set_loglevel(module._verbosity)
     result = RESULT(
         http_code=0,
         msg="Nothing to be done",
@@ -278,51 +283,61 @@ def run_module():
         changed=False,
     )
 
+    passwordget = PasswordsGetAPI(module, logger=logger)
+    checkmkversion = CheckmkVersion(str(passwordget.getversion()))
+
+    if checkmkversion >= CheckmkVersion("2.6.0"):
+        if "owner" in module.params:
+            logger.debug("Checkmk Version %s needs 'editable_by' instead of 'owner'" % 
+                         str(checkmkversion))
+            module.params["editable_by"] = module.params.pop("owner")
+
     if module.params.get("state") == "present":
-        passwordget = PasswordsGetAPI(module)
         result = passwordget.get()
 
         if result.http_code == 200:
-            passwordupdate = PasswordsUpdateAPI(module)
+            passwordupdate = PasswordsUpdateAPI(module, logger=logger)
             passwordupdate.headers["If-Match"] = result.etag
             result = passwordupdate.put()
 
             time.sleep(3)
 
         elif result.http_code == 404:
-            passwordcreate = PasswordsCreateAPI(module)
+            passwordcreate = PasswordsCreateAPI(module, logger=logger)
 
-            checkmkversion = CheckmkVersion(str(passwordcreate.getversion()))
             if (
                 checkmkversion.edition in ("ultimatemt", "cme")
                 and module.params.get("customer") is None
             ):
-                result = RESULT(
+                exit_module(
+                    module,
                     http_code=0,
                     msg="Missing required parameter 'customer' for Checkmk Ultimate with multi-tenancy",
                     content="",
-                    etag="",
                     failed=True,
                     changed=False,
+                    logger=logger,
                 )
-                module.fail_json(**result_as_dict(result))
 
             result = passwordcreate.post()
 
             time.sleep(3)
 
     if module.params.get("state") == "absent":
-        passwordget = PasswordsGetAPI(module)
         result = passwordget.get()
 
         if result.http_code == 200:
-            passworddelete = PasswordsDeleteAPI(module)
+            passworddelete = PasswordsDeleteAPI(module, logger=logger)
             passworddelete.headers["If-Match"] = result.etag
             result = passworddelete.delete()
 
             time.sleep(3)
 
-    module.exit_json(**result_as_dict(result))
+    exit_module(
+        module,
+        result=result,
+        logger=logger,
+    )
 
 
 def main():

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -55,10 +55,11 @@ options:
         required: false
         type: str
 
-    owner:
+    editable_by:
         description: Each password is owned by a group of users which are able to edit, delete and use existing passwords.
         required: false
         type: str
+        aliases: ["owner"]
 
     shared:
         description: The list of members to share the password with.
@@ -193,6 +194,13 @@ HTTP_CODES_DELETE = {
 }
 
 
+def _owner_or_editable_by(checkmkversion):
+    if checkmkversion < CheckmkVersion("2.3.0p23"):
+        return "owner"
+    else:
+        return "editable_by"
+
+
 class PasswordsCreateAPI(CheckmkAPI):
     def post(self):
         data = {
@@ -202,7 +210,8 @@ class PasswordsCreateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            "owner": self.params.get("owner", ""),
+            _owner_or_editable_by(self.getversion()):
+                self.params.get("editable_by", self.params.get("owner", "")),
             "shared": self.params.get("shared", ""),
         }
 
@@ -224,7 +233,8 @@ class PasswordsUpdateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            "owner": self.params.get("owner", ""),
+            _owner_or_editable_by(self.getversion()):
+                self.params.get("editable_by", self.params.get("owner", "")),
             "shared": self.params.get("shared", ""),
         }
 
@@ -266,7 +276,7 @@ def run_module():
         comment=dict(type="str", required=False),
         documentation_url=dict(type="str", required=False),
         password=dict(type="str", required=False, no_log=True),
-        owner=dict(type="str", required=False),
+        editable_by=dict(type="str", required=False, aliases=["owner"]),
         shared=dict(type="raw", required=False),
         state=dict(type="str", default="present", choices=["present", "absent"]),
     )
@@ -285,12 +295,6 @@ def run_module():
 
     passwordget = PasswordsGetAPI(module, logger=logger)
     checkmkversion = CheckmkVersion(str(passwordget.getversion()))
-
-    if checkmkversion >= CheckmkVersion("2.6.0"):
-        if "owner" in module.params:
-            logger.debug("Checkmk Version %s needs 'editable_by' instead of 'owner'" % 
-                         str(checkmkversion))
-            module.params["editable_by"] = module.params.pop("owner")
 
     if module.params.get("state") == "present":
         result = passwordget.get()

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -174,7 +174,6 @@ from ansible_collections.checkmk.general.plugins.module_utils.types import RESUL
 from ansible_collections.checkmk.general.plugins.module_utils.utils import (
     base_argument_spec,
     exit_module,
-    result_as_dict,
 )
 from ansible_collections.checkmk.general.plugins.module_utils.version import (
     CheckmkVersion,
@@ -210,8 +209,9 @@ class PasswordsCreateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            _owner_or_editable_by(self.getversion()):
-                self.params.get("editable_by", self.params.get("owner", "")),
+            _owner_or_editable_by(self.getversion()): self.params.get(
+                "editable_by", self.params.get("owner", "")
+            ),
             "shared": self.params.get("shared", ""),
         }
 
@@ -233,8 +233,9 @@ class PasswordsUpdateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            _owner_or_editable_by(self.getversion()):
-                self.params.get("editable_by", self.params.get("owner", "")),
+            _owner_or_editable_by(self.getversion()): self.params.get(
+                "editable_by", self.params.get("owner", "")
+            ),
             "shared": self.params.get("shared", ""),
         }
 

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -56,7 +56,9 @@ options:
         type: str
 
     editable_by:
-        description: Each password is owned by a group of users which are able to edit, delete and use existing passwords.
+        description:
+        - Each password is owned by a group of users which are able to edit, delete and use existing passwords.
+        - Use O(editable_by) in new playbooks. O(owner) is a deprecated alias kept for backward compatibility.
         required: false
         type: str
         aliases: ["owner"]

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -205,7 +205,7 @@ def _owner_or_editable_by(version):
 
 
 class PasswordsCreateAPI(CheckmkAPI):
-    def post(self, version=None):
+    def post(self, version):
         data = {
             "ident": self.params.get("name", ""),
             "title": self.params.get("title", ""),
@@ -230,7 +230,7 @@ class PasswordsCreateAPI(CheckmkAPI):
 
 
 class PasswordsUpdateAPI(CheckmkAPI):
-    def put(self, version=None):
+    def put(self, version):
         data = {
             "title": self.params.get("title", ""),
             "customer": self.params.get("customer", ""),
@@ -307,7 +307,7 @@ def run_module():
         if result.http_code == 200:
             passwordupdate = PasswordsUpdateAPI(module, logger=logger)
             passwordupdate.headers["If-Match"] = result.etag
-            result = passwordupdate.put(version=version)
+            result = passwordupdate.put(version)
 
             time.sleep(3)
 
@@ -328,7 +328,7 @@ def run_module():
                     logger=logger,
                 )
 
-            result = passwordcreate.post(version=version)
+            result = passwordcreate.post(version)
 
             time.sleep(3)
 

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -182,6 +182,7 @@ from ansible_collections.checkmk.general.plugins.module_utils.version import (
 )
 
 logger = Logger()
+checkmkversion = None
 
 # We count 404 not as failed, because we want to know if the password exists or not.
 HTTP_CODES_GET = {
@@ -195,7 +196,7 @@ HTTP_CODES_DELETE = {
 }
 
 
-def _owner_or_editable_by(checkmkversion):
+def _owner_or_editable_by():
     if checkmkversion < CheckmkVersion("2.3.0p23"):
         return "owner"
     else:
@@ -211,7 +212,7 @@ class PasswordsCreateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            _owner_or_editable_by(self.getversion()): self.params.get(
+            _owner_or_editable_by(): self.params.get(
                 "editable_by", self.params.get("owner", "")
             ),
             "shared": self.params.get("shared", ""),
@@ -235,7 +236,7 @@ class PasswordsUpdateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            _owner_or_editable_by(self.getversion()): self.params.get(
+            _owner_or_editable_by(): self.params.get(
                 "editable_by", self.params.get("owner", "")
             ),
             "shared": self.params.get("shared", ""),

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -182,7 +182,6 @@ from ansible_collections.checkmk.general.plugins.module_utils.version import (
 )
 
 logger = Logger()
-checkmkversion = None
 
 # We count 404 not as failed, because we want to know if the password exists or not.
 HTTP_CODES_GET = {
@@ -196,15 +195,17 @@ HTTP_CODES_DELETE = {
 }
 
 
-def _owner_or_editable_by():
-    if checkmkversion < CheckmkVersion("2.3.0p23"):
+def _owner_or_editable_by(version):
+    if version < CheckmkVersion("2.3.0p23"):
+        logger.debug("Using 'owner', as version is %s" % str(version))
         return "owner"
     else:
+        logger.debug("Using 'editable_by', as version is %s" % str(version))
         return "editable_by"
 
 
 class PasswordsCreateAPI(CheckmkAPI):
-    def post(self):
+    def post(self, version=None):
         data = {
             "ident": self.params.get("name", ""),
             "title": self.params.get("title", ""),
@@ -212,7 +213,7 @@ class PasswordsCreateAPI(CheckmkAPI):
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            _owner_or_editable_by(): self.params.get(
+            _owner_or_editable_by(version): self.params.get(
                 "editable_by", self.params.get("owner", "")
             ),
             "shared": self.params.get("shared", ""),
@@ -229,14 +230,14 @@ class PasswordsCreateAPI(CheckmkAPI):
 
 
 class PasswordsUpdateAPI(CheckmkAPI):
-    def put(self):
+    def put(self, version=None):
         data = {
             "title": self.params.get("title", ""),
             "customer": self.params.get("customer", ""),
             "comment": self.params.get("comment", ""),
             "documentation_url": self.params.get("documentation_url", ""),
             "password": self.params.get("password", ""),
-            _owner_or_editable_by(): self.params.get(
+            _owner_or_editable_by(version): self.params.get(
                 "editable_by", self.params.get("owner", "")
             ),
             "shared": self.params.get("shared", ""),
@@ -297,16 +298,16 @@ def run_module():
         changed=False,
     )
 
-    if module.params.get("state") == "present":
-        passwordget = PasswordsGetAPI(module, logger=logger)
-        checkmkversion = CheckmkVersion(str(passwordget.getversion()))
+    passwordget = PasswordsGetAPI(module, logger=logger)
 
+    if module.params.get("state") == "present":
+        version = passwordget.getversion()
         result = passwordget.get()
 
         if result.http_code == 200:
             passwordupdate = PasswordsUpdateAPI(module, logger=logger)
             passwordupdate.headers["If-Match"] = result.etag
-            result = passwordupdate.put()
+            result = passwordupdate.put(version=version)
 
             time.sleep(3)
 
@@ -314,7 +315,7 @@ def run_module():
             passwordcreate = PasswordsCreateAPI(module, logger=logger)
 
             if (
-                checkmkversion.edition in ("ultimatemt", "cme")
+                version.edition in ("ultimatemt", "cme")
                 and module.params.get("customer") is None
             ):
                 exit_module(
@@ -327,7 +328,7 @@ def run_module():
                     logger=logger,
                 )
 
-            result = passwordcreate.post()
+            result = passwordcreate.post(version=version)
 
             time.sleep(3)
 


### PR DESCRIPTION
## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?

The parameter "owner" was renamed to "editable_by", and the old parameter is no longer valid in Checkmk 3.0.0
See [Werk17274](https://checkmk.com/werk/19721)

## What is the new behavior?

- Only for versions older that 2.3.0p23, we use the parameter "owner"
- Else, the parameter "editable_by" is used.
- From an Ansible perspective, we will keep the old parameter name as an alias but encourage users to change their playbooks to use the new name.