### PR TITLE
Re-add `ansible-core 2.16` to testing

### DIFF
--- a/.github/workflows/_template-ans-int-test.yaml
+++ b/.github/workflows/_template-ans-int-test.yaml
@@ -31,6 +31,7 @@ jobs:
       max-parallel: 2
       matrix:
         ansible:
+          - stable-2.16
           - stable-2.19
           - stable-2.20
           - stable-2.21

--- a/.github/workflows/_template-ans-unit-test.yaml
+++ b/.github/workflows/_template-ans-unit-test.yaml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
+          - stable-2.16
           - stable-2.19
           - stable-2.20
           - stable-2.21

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -69,6 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
+          - stable-2.16
           - stable-2.19
           - stable-2.20
           - stable-2.21

--- a/.github/workflows/ansible-sanity-tests.yaml
+++ b/.github/workflows/ansible-sanity-tests.yaml
@@ -39,6 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
+          - stable-2.16
+          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20


### PR DESCRIPTION
Apparently Ansible 2.16 this is the default version on RHEL up to 10 and clones. So we should test for it.

## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

Both Integration and Sanity tests now test against Ansible 2.16 again.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
