### PR TITLE
Move OMD configuration management before state management

### DIFF
--- a/changelogs/fragments/server.yml
+++ b/changelogs/fragments/server.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - Server role - Apply the OMD site configuration before starting the site.
+    Previously, a stopped site (e.g. freshly created or just updated) with
+    ``omd_config`` defined was started first, only to be stopped again
+    immediately to apply the configuration. Now the configuration is applied
+    while the site is still stopped and the site is started only once.

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -76,6 +76,19 @@
   tags:
     - enable-sites
 
+- name: "Include Site Configuration Management."
+  ansible.builtin.include_tasks: configure-site.yml
+  loop: "{{ checkmk_server_sites }}"
+  loop_control:
+    label: "{{ outer_item | combine({'admin_pw': omit}) }}"
+    loop_var: outer_item
+  when: |
+    outer_item.omd_config is defined and
+    ((outer_item.omd_auto_restart is defined and outer_item.omd_auto_restart | bool) or
+    (outer_item.state == "stopped" or outer_item.state == "disabled" or outer_item.state == "present"))
+  tags:
+    - configure-sites
+
 - name: "Start Sites."
   become: true
   ansible.builtin.shell: |
@@ -147,19 +160,6 @@
   register: __checkmk_server_sites_removed
   tags:
     - destroy-sites
-
-- name: "Include Site Configuration Management."
-  ansible.builtin.include_tasks: configure-site.yml
-  loop: "{{ checkmk_server_sites }}"
-  loop_control:
-    label: "{{ outer_item | combine({'admin_pw': omit}) }}"
-    loop_var: outer_item
-  when: |
-    outer_item.omd_config is defined and
-    ((outer_item.omd_auto_restart is defined and outer_item.omd_auto_restart | bool) or
-    (outer_item.state == "stopped" or outer_item.state == "disabled" or outer_item.state == "present"))
-  tags:
-    - configure-sites
 
 - name: "Include MKP Management."
   ansible.builtin.include_tasks: mkp.yml


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Previously, a stopped site (e.g., freshly created or just updated) with `omd_config` defined was started first, only to be stopped again immediately to apply the configuration. Now the configuration is applied while the site is still stopped and the site is started only once.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
