### PR TITLE
Make admin user password management idempotent.

### DIFF
--- a/changelogs/fragments/server.yml
+++ b/changelogs/fragments/server.yml
@@ -4,3 +4,7 @@ minor_changes:
     ``omd_config`` defined was started first, only to be stopped again
     immediately to apply the configuration. Now the configuration is applied
     while the site is still stopped and the site is started only once.
+bugfixes:
+  - Server role - Only update the site admin password when it actually
+    differs from the configured one. Previously, the password hash was
+    rewritten on every run, breaking idempotence.

--- a/changelogs/fragments/server.yml
+++ b/changelogs/fragments/server.yml
@@ -6,5 +6,4 @@ minor_changes:
     while the site is still stopped and the site is started only once.
 bugfixes:
   - Server role - Only update the site admin password when it actually
-    differs from the configured one. Previously, the password hash was
-    rewritten on every run, breaking idempotence.
+    differs from the configured one.

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -169,11 +169,15 @@
     loop_var: __site
   when: __site.mkp_packages is defined
 
-- name: "Update Site Admin Password for Checkmk < 2.1."  # noqa no-changed-when
+- name: "Update Site Admin Password for Checkmk < 2.1."
   become: true
   ansible.builtin.shell: |
     set -o pipefail
-    echo '{{ item.admin_pw }}' | htpasswd -i /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin
+    if ! echo '{{ item.admin_pw }}' | htpasswd -vi /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin > /dev/null 2>&1
+    then
+      echo '{{ item.admin_pw }}' | htpasswd -i /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin
+      echo "Password updated."
+    fi
   args:
     executable: /bin/bash
   no_log: "{{ checkmk_server_no_log | bool }}"
@@ -181,16 +185,22 @@
   loop_control:
     label: "{{ item | combine({'admin_pw': omit}) }}"
   when: item.admin_pw is defined and (item.state != "absent") and (item.version | regex_replace('p.*', '') is version('2.1', '<'))
+  register: __checkmk_server_admin_pw_legacy
+  changed_when: "'Password updated.' in __checkmk_server_admin_pw_legacy.stdout"
   tags:
     - set-site-admin-pw
 
 # In the future this should be done with 'cmk-passwd' available from 2.1.0p16 (https://checkmk.com/werk/14389)
 # To keep things simple, we do it in a more generic way here, which works in all 2.1 releases
-- name: "Update Site Admin Password for Checkmk >= 2.1."  # noqa no-changed-when
+- name: "Update Site Admin Password for Checkmk >= 2.1."
   become: true
   ansible.builtin.shell: |
     set -o pipefail
-    echo '{{ item.admin_pw }}' | htpasswd -i -B -C 12 /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin
+    if ! echo '{{ item.admin_pw }}' | htpasswd -vi /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin > /dev/null 2>&1
+    then
+      echo '{{ item.admin_pw }}' | htpasswd -i -B -C 12 /omd/sites/{{ item.name }}/etc/htpasswd cmkadmin
+      echo "Password updated."
+    fi
   args:
     executable: /bin/bash
   no_log: "{{ checkmk_server_no_log | bool }}"
@@ -198,6 +208,8 @@
   loop_control:
     label: "{{ item | combine({'admin_pw': omit}) }}"
   when: item.admin_pw is defined and (item.state != "absent") and (item.version | regex_replace('p.*', '') is version('2.1', '>='))
+  register: __checkmk_server_admin_pw
+  changed_when: "'Password updated.' in __checkmk_server_admin_pw.stdout"
   tags:
     - set-site-admin-pw
 


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Previously, the site admin password was rewritten on every run, breaking idempotence. Now the password is only updated, when it actually differs from the configured one.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
