### PR TITLE
Improve idempotence of the rule module

### DIFF
--- a/changelogs/fragments/rule_idempotency.yml
+++ b/changelogs/fragments/rule_idempotency.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - rule module - Fail as documented when the provided ``rule_id`` does not exist, instead of reporting an unchanged success.
   - rule module - Compare rule values structurally instead of rewriting parentheses to brackets, which silently ignored real changes to values containing parentheses or brackets inside strings.
+  - rule module - Translate ``host_labels`` and ``service_labels`` conditions to the label group format used by Checkmk 2.3 and newer, preventing a new rule from being created on every run when the old syntax is used.

--- a/changelogs/fragments/rule_idempotency.yml
+++ b/changelogs/fragments/rule_idempotency.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - rule module - Fail as documented when the provided ``rule_id`` does not exist, instead of reporting an unchanged success.
+  - rule module - Compare rule values structurally instead of rewriting parentheses to brackets, which silently ignored real changes to values containing parentheses or brackets inside strings.

--- a/changelogs/fragments/rule_idempotency.yml
+++ b/changelogs/fragments/rule_idempotency.yml
@@ -3,3 +3,4 @@ bugfixes:
   - rule module - Compare rule values structurally instead of rewriting parentheses to brackets, which silently ignored real changes to values containing parentheses or brackets inside strings.
   - rule module - Translate ``host_labels`` and ``service_labels`` conditions to the label group format used by Checkmk 2.3 and newer, preventing a new rule from being created on every run when the old syntax is used.
   - rule module - Do not issue a superfluous move API call when creating a rule with the default location.
+  - rule module - Fix documentation examples that used a value format rejected by Checkmk 2.5, and document value format requirements, secret masking and rule location semantics.

--- a/changelogs/fragments/rule_idempotency.yml
+++ b/changelogs/fragments/rule_idempotency.yml
@@ -2,3 +2,4 @@ bugfixes:
   - rule module - Fail as documented when the provided ``rule_id`` does not exist, instead of reporting an unchanged success.
   - rule module - Compare rule values structurally instead of rewriting parentheses to brackets, which silently ignored real changes to values containing parentheses or brackets inside strings.
   - rule module - Translate ``host_labels`` and ``service_labels`` conditions to the label group format used by Checkmk 2.3 and newer, preventing a new rule from being created on every run when the old syntax is used.
+  - rule module - Do not issue a superfluous move API call when creating a rule with the default location.

--- a/changelogs/fragments/rule_idempotency.yml
+++ b/changelogs/fragments/rule_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rule module - Fail as documented when the provided ``rule_id`` does not exist, instead of reporting an unchanged success.

--- a/changelogs/fragments/rule_idempotency.yml
+++ b/changelogs/fragments/rule_idempotency.yml
@@ -4,3 +4,4 @@ bugfixes:
   - rule module - Translate ``host_labels`` and ``service_labels`` conditions to the label group format used by Checkmk 2.3 and newer, preventing a new rule from being created on every run when the old syntax is used.
   - rule module - Do not issue a superfluous move API call when creating a rule with the default location.
   - rule module - Fix documentation examples that used a value format rejected by Checkmk 2.5, and document value format requirements, secret masking and rule location semantics.
+  - rule module - Do not modify the desired and current rule while normalizing them for comparison, so that the data sent to the API no longer depends on comparison side effects.

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -457,6 +457,15 @@ POSITION_MAPPING = {
 }
 
 
+def _tuples_to_lists(value):
+    # Only containers are converted; string contents are never touched.
+    if isinstance(value, (list, tuple)):
+        return [_tuples_to_lists(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _tuples_to_lists(v) for k, v in value.items()}
+    return value
+
+
 class RuleHTTPCodes:
     # http_code: (changed, failed, "Message")
     get = {
@@ -657,19 +666,18 @@ class RuleAPI(CheckmkAPI):
     def _raw_value_eval(self, state, data):
         value_raw = data.get("value_raw", "''")
 
-        # This is an ugly hack that translates tuples into lists to have a better hit rate with
-        # idempotency.
-        # Once the internal handling of value_raw has improved, we will no longer need this.
-        value_raw = value_raw.translate(str.maketrans("()", "[]"))
-
         # As safely as possible evaluate the value_raw
         try:
-            return literal_eval(value_raw)
+            value = literal_eval(value_raw)
 
         except Exception as e:
             self.module.fail_json(
                 msg="ERROR: The %s value_raw has invalid format: %s" % (state, e)
             )
+
+        # Tuples and lists are interchangeable in rule values as far as
+        # change detection is concerned.
+        return _tuples_to_lists(value)
 
     def _get_rules_in_ruleset(self, ruleset):
         result = self._fetch(

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -661,7 +661,32 @@ class RuleAPI(CheckmkAPI):
                 if not desired["rule"].get(what).get(key):
                     desired["rule"][what][key] = value
 
+        if self.version_select_str == "230_or_newer":
+            self._migrate_label_conditions(desired["rule"].get("conditions", {}))
+
         return desired
+
+    def _migrate_label_conditions(self, conditions):
+        # Checkmk >= 2.3 stores plain label conditions as label groups.
+        # Apply the same translation to the desired state, so that both
+        # comparing against and sending to the API use the migrated format.
+        for old_key, new_key in (
+            ("host_labels", "host_label_groups"),
+            ("service_labels", "service_label_groups"),
+        ):
+            labels = conditions.pop(old_key, None)
+            if not labels:
+                continue
+            label_group = [
+                {
+                    "operator": ("not" if label.get("operator") == "is_not" else "and"),
+                    "label": "%s:%s" % (label.get("key"), label.get("value")),
+                }
+                for label in labels
+            ]
+            if not conditions.get(new_key):
+                conditions[new_key] = []
+            conditions[new_key].append({"operator": "and", "label_group": label_group})
 
     def _raw_value_eval(self, state, data):
         value_raw = data.get("value_raw", "''")

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -48,7 +48,7 @@ options:
                         description:
                             - Position of the rule in the folder.
                             - Has no effect when I(state=absent).
-                            - For new rule C(any) wil be equivalent to C(bottom).
+                            - For a new rule C(any) will be equivalent to C(bottom).
                         required: false
                         type: str
                         choices:
@@ -100,11 +100,19 @@ options:
         default: present
         type: str
 notes:
-    - If rule_id is omitted, due to the internal processing of the C(value_raw), finding the
-      matching rule is not reliable, when C(rule_id) is omitted. This sometimes leads to the
-      module not being idempotent or to rules being created over and over again.
-    - If rule_id is provided, for the same reason, it might happen, that tasks changing a rule
-      again and again, even if it already meets the expectations.
+    - Provide C(value_raw) in the canonical format of the target Checkmk version,
+      for example by copying it from the GUI (Export rule for API) or from the output
+      of an existing rule. Value formats can change between Checkmk versions, so
+      playbooks may need updating after a Checkmk upgrade.
+    - Rules containing passwords or other secrets cannot be compared reliably, because
+      the Checkmk API masks secrets in its responses. Such tasks report a change on
+      every run when C(rule_id) is provided, or create a new rule on every run when it
+      is omitted. Referencing an entry from the password store and writing the value
+      exactly as the API returns it avoids this.
+    - The positions C(top), C(bottom), C(before) and C(after) describe the rule order
+      at the time the task runs. Rules created later, including by subsequent tasks,
+      can displace such rules, causing move operations on the next run. Only C(any)
+      is stable in that regard.
 
 seealso:
     - plugin: checkmk.general.rule
@@ -134,7 +142,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_name:
@@ -145,7 +153,7 @@ EXAMPLES = r"""
         host_labels: []
         service_labels: []
       properties:
-        description: "Allow higher memory usage on myhost01"
+        description: "Allow higher filesystem usage on myhost01"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"
@@ -165,7 +173,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       rule_id: "{{ rule_result.content.id }}"
     state: "absent"
@@ -180,7 +188,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_name:
@@ -191,7 +199,7 @@ EXAMPLES = r"""
         host_labels: []
         service_labels: []
       properties:
-        description: "Allow even higher memory usage on myhost02"
+        description: "Allow even higher filesystem usage on myhost02"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (85.0, 99.0)}"
@@ -210,7 +218,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_labels:
@@ -218,7 +226,7 @@ EXAMPLES = r"""
             operator: "is"
             value: "yes"
       properties:
-        description: "Allow higher memory usage on Checkmk servers"
+        description: "Allow higher filesystem usage on Checkmk servers"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"
@@ -233,7 +241,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_label_groups:
@@ -246,7 +254,7 @@ EXAMPLES = r"""
         host_tags: []
         service_label_groups: []
       properties:
-        description: "Allow higher memory usage on Linux hosts in mysite"
+        description: "Allow higher filesystem usage on Linux hosts in mysite"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"
@@ -265,13 +273,13 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       rule_id: "{{ item.id }}"
     state: "absent"
   loop: "{{
            lookup('checkmk.general.rules',
-             ruleset='checkgroup_parameters:memory_percentage_used',
+             ruleset='checkgroup_parameters:filesystem',
              comment_regex='Managed by Ansible',
              server_url='https://myserver/',
              site='mysite',
@@ -293,10 +301,10 @@ EXAMPLES = r"""
 
 - name: "Create a rule using environment variables for authentication."
   checkmk.general.rule:
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       properties:
-        description: "Allow higher memory usage"
+        description: "Allow higher filesystem usage"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -631,7 +631,8 @@ class RuleAPI(CheckmkAPI):
             )
 
     def rule_id_found(self):
-        return self.current is not None
+        # _get_rule_by_id returns an empty dict when the rule does not exist.
+        return bool(self.current)
 
     def _clean_desired(self, params):
         desired = {}
@@ -986,7 +987,7 @@ def run_module():
     )
 
     desired_state = module.params.get("state")
-    rule_id = module.params.get("rule_id")
+    rule_id = module.params.get("rule", {}).get("rule_id")
 
     if desired_state == "present":
         if current_rule.rule_id_found():

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -829,12 +829,9 @@ class RuleAPI(CheckmkAPI):
 
         if self.is_new_rule:
             location = self.desired.get("rule").get("location")
-            if location and not (
-                # folder should be there
-                location.get("folder", "/") == "/"
-                # position should be there
-                and location.get("position", "bottom") == "bottom"
-            ):
+            # create() already places the rule at the bottom of the target
+            # folder, so only the other positions need an extra move call.
+            if location and location.get("position", "any") not in ("bottom", "any"):
                 return True
 
         return False

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -48,7 +48,7 @@ options:
                         description:
                             - Position of the rule in the folder.
                             - Has no effect when I(state=absent).
-                            - For new rule C(any) wil be equivalent to C(bottom).
+                            - For a new rule C(any) will be equivalent to C(bottom).
                         required: false
                         type: str
                         choices:
@@ -100,11 +100,19 @@ options:
         default: present
         type: str
 notes:
-    - If rule_id is omitted, due to the internal processing of the C(value_raw), finding the
-      matching rule is not reliable, when C(rule_id) is omitted. This sometimes leads to the
-      module not being idempotent or to rules being created over and over again.
-    - If rule_id is provided, for the same reason, it might happen, that tasks changing a rule
-      again and again, even if it already meets the expectations.
+    - Provide C(value_raw) in the canonical format of the target Checkmk version,
+      for example by copying it from the GUI (Export rule for API) or from the output
+      of an existing rule. Value formats can change between Checkmk versions, so
+      playbooks may need updating after a Checkmk upgrade.
+    - Rules containing passwords or other secrets cannot be compared reliably, because
+      the Checkmk API masks secrets in its responses. Such tasks report a change on
+      every run when C(rule_id) is provided, or create a new rule on every run when it
+      is omitted. Referencing an entry from the password store and writing the value
+      exactly as the API returns it avoids this.
+    - The positions C(top), C(bottom), C(before) and C(after) describe the rule order
+      at the time the task runs. Rules created later, including by subsequent tasks,
+      can displace such rules, causing move operations on the next run. Only C(any)
+      is stable in that regard.
 
 seealso:
     - plugin: checkmk.general.rule
@@ -134,7 +142,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_name:
@@ -145,7 +153,7 @@ EXAMPLES = r"""
         host_labels: []
         service_labels: []
       properties:
-        description: "Allow higher memory usage on myhost01"
+        description: "Allow higher filesystem usage on myhost01"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"
@@ -165,7 +173,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       rule_id: "{{ rule_result.content.id }}"
     state: "absent"
@@ -180,7 +188,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_name:
@@ -191,7 +199,7 @@ EXAMPLES = r"""
         host_labels: []
         service_labels: []
       properties:
-        description: "Allow even higher memory usage on myhost02"
+        description: "Allow even higher filesystem usage on myhost02"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (85.0, 99.0)}"
@@ -210,7 +218,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_labels:
@@ -218,7 +226,7 @@ EXAMPLES = r"""
             operator: "is"
             value: "yes"
       properties:
-        description: "Allow higher memory usage on Checkmk servers"
+        description: "Allow higher filesystem usage on Checkmk servers"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"
@@ -233,7 +241,7 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       conditions:
         host_label_groups:
@@ -246,7 +254,7 @@ EXAMPLES = r"""
         host_tags: []
         service_label_groups: []
       properties:
-        description: "Allow higher memory usage on Linux hosts in mysite"
+        description: "Allow higher filesystem usage on Linux hosts in mysite"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"
@@ -265,13 +273,13 @@ EXAMPLES = r"""
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       rule_id: "{{ item.id }}"
     state: "absent"
   loop: "{{
            lookup('checkmk.general.rules',
-             ruleset='checkgroup_parameters:memory_percentage_used',
+             ruleset='checkgroup_parameters:filesystem',
              comment_regex='Managed by Ansible',
              server_url='https://myserver',
              site='mysite',
@@ -293,10 +301,10 @@ EXAMPLES = r"""
 
 - name: "Create a rule using environment variables for authentication."
   checkmk.general.rule:
-    ruleset: "checkgroup_parameters:memory_percentage_used"
+    ruleset: "checkgroup_parameters:filesystem"
     rule:
       properties:
-        description: "Allow higher memory usage"
+        description: "Allow higher filesystem usage"
         comment: "Managed by Ansible"
         disabled: false
       value_raw: "{'levels': (80.0, 90.0)}"

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -104,15 +104,32 @@ notes:
       for example by copying it from the GUI (Export rule for API) or from the output
       of an existing rule. Value formats can change between Checkmk versions, so
       playbooks may need updating after a Checkmk upgrade.
-    - Rules containing passwords or other secrets cannot be compared reliably, because
-      the Checkmk API masks secrets in its responses. Such tasks report a change on
-      every run when C(rule_id) is provided, or create a new rule on every run when it
-      is omitted. Referencing an entry from the password store and writing the value
-      exactly as the API returns it avoids this.
+    - The Checkmk API masks secrets in its responses. Rules that contain an explicit
+      password in C(value_raw) can therefore never be compared with the desired state.
+      They report a change on every run when C(rule_id) is provided, and create another
+      rule on every run when it is omitted. Reference an entry of the Checkmk password
+      store instead, which can be managed with the M(checkmk.general.password) module.
+      This is the only supported way to manage rules containing secrets with this module.
+    - Write the password store reference exactly as the target Checkmk site returns it,
+      because its representation depends on the Checkmk version and on the ruleset.
+      Rulesets using the modern rule specs return for example
+      C(('cmk_postprocessed', 'stored_password', ('my_password', ''))) on Checkmk 2.3 and
+      2.4, and C(('cmk_postprocessed', 'stored_password', ('my_password', '******'))) on
+      Checkmk 2.5, while rulesets still using the legacy valuespecs return
+      C(('store', 'my_password')). The last element of such a reference is not evaluated
+      for password store entries, so the masked value can be used as it is returned.
     - The positions C(top), C(bottom), C(before) and C(after) describe the rule order
-      at the time the task runs. Rules created later, including by subsequent tasks,
-      can displace such rules, causing move operations on the next run. Only C(any)
-      is stable in that regard.
+      at the time the task runs. Rules created later, including by subsequent tasks or
+      in the GUI, can displace such rules, so the next run detects a location change
+      and moves the rule back.
+    - C(position=any) accepts any position within the folder and is thus the only
+      position that is idempotent on its own. Do not use it for rulesets that are
+      evaluated in first match order, because the rule which takes effect would then
+      depend on an arbitrary position. Order the rules of such a ruleset explicitly,
+      as shown in the examples, anchoring the first rule and chaining the following
+      ones behind their predecessor with C(position=after) and C(neighbour). Once
+      established, such a chain is idempotent, and it restores the intended order if
+      rules are inserted in between.
 
 seealso:
     - plugin: checkmk.general.rule
@@ -261,6 +278,53 @@ EXAMPLES = r"""
       location:
         folder: "/"
         position: "bottom"
+    state: "present"
+
+# ---------------------------------------------------------------------------
+# Ordered rules in a ruleset that is evaluated in first match order
+# ---------------------------------------------------------------------------
+# Anchor the first rule of the chain, then chain every following rule behind
+# its predecessor. The relative order of the rules is then guaranteed and
+# idempotent, regardless of other rules in the same folder.
+
+- name: "Create the more specific rule first."
+  checkmk.general.rule:
+    server_url: "https://myserver"
+    site: "mysite"
+    api_user: "myuser"
+    api_secret: "mysecret"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      conditions:
+        host_labels:
+          - key: "role"
+            operator: "is"
+            value: "database"
+      properties:
+        description: "Filesystem levels for database servers"
+        comment: "Managed by Ansible"
+      value_raw: "{'levels': (95.0, 98.0)}"
+      location:
+        folder: "/"
+        position: "any"
+    state: "present"
+  register: database_rule
+
+- name: "Create the general rule directly after the specific one."
+  checkmk.general.rule:
+    server_url: "https://myserver"
+    site: "mysite"
+    api_user: "myuser"
+    api_secret: "mysecret"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      properties:
+        description: "Filesystem levels for all other hosts"
+        comment: "Managed by Ansible"
+      value_raw: "{'levels': (80.0, 90.0)}"
+      location:
+        position: "after"
+        neighbour: "{{ database_rule.content.id }}"
     state: "present"
 
 # ---------------------------------------------------------------------------

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -443,6 +443,7 @@ content:
 
 import json
 from ast import literal_eval
+from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.checkmk.general.plugins.module_utils.api import CheckmkAPI
@@ -807,17 +808,16 @@ class RuleAPI(CheckmkAPI):
         return None
 
     def _normalize_rule(self, r):
-        loc = r.copy()
+        # Work on a deep copy: normalizing must not modify the rule that was
+        # passed in, which would silently alter self.desired or self.current.
+        loc = deepcopy(r)
         for what, def_vals in IGNORE_DEFAULTS[self.version_select_str].items():
-            if loc.get(what):
+            for candidate in (loc, loc.get("extensions", {})):
+                if not candidate.get(what):
+                    continue
                 for key, value in def_vals.items():
-                    if loc.get(what).get(key, value) == value:
-                        loc[what].pop(key, None)
-            if loc.get("extensions", {}).get(what):
-                ext = loc.get("extensions", {})
-                for key, value in def_vals.items():
-                    if ext.get(what).get(key, value) == value:
-                        ext[what].pop(key, None)
+                    if candidate[what].get(key, value) == value:
+                        candidate[what].pop(key, None)
         return loc
 
     def _detect_changes(self):
@@ -954,7 +954,7 @@ class RuleAPI(CheckmkAPI):
 
     def create(self):
         # rule is there always (required true)
-        data = self.desired.get("rule").copy()
+        data = self._normalize_rule(self.desired.get("rule"))
         location = data.pop("location", {})
         data["ruleset"] = self.desired.get("ruleset")
         data["folder"] = location.get("folder", "/")
@@ -988,8 +988,8 @@ class RuleAPI(CheckmkAPI):
 
     def edit(self):
         # rule is there always (required true)
-        data = self.desired.get("rule").copy()
-        data.pop("location")
+        data = self._normalize_rule(self.desired.get("rule"))
+        data.pop("location", None)
         self.headers["if-Match"] = self.etag
 
         if not data.get("value_raw"):

--- a/tests/integration/targets/rule/tasks/test.yml
+++ b/tests/integration/targets/rule/tasks/test.yml
@@ -147,3 +147,296 @@
   loop_control:
     label: "{{ item.content.id }}"
   environment: "{{ __checkmk_var_testing_environment }}"
+
+# ---------------------------------------------------------------------------
+# Regression tests for previously fixed idempotency defects
+# ---------------------------------------------------------------------------
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule with parentheses inside a value."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "custom_checks"
+    rule:
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - parentheses in values"
+        disabled: false
+      value_raw: "{'service_description': 'Ansible test', 'command_line': 'echo (1)'}"
+      location:
+        folder: "/"
+        position: "any"
+    state: "present"
+  register: __checkmk_var_result_parentheses_create
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule with parentheses inside a value. Again."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "custom_checks"
+    rule:
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - parentheses in values"
+        disabled: false
+      value_raw: "{'service_description': 'Ansible test', 'command_line': 'echo (1)'}"
+      location:
+        folder: "/"
+        position: "any"
+    state: "present"
+  register: __checkmk_var_result_parentheses_again
+  failed_when: __checkmk_var_result_parentheses_again.changed
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Replace the parentheses inside the value with brackets."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "custom_checks"
+    rule:
+      rule_id: "{{ __checkmk_var_result_parentheses_create.content.id }}"
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - parentheses in values"
+        disabled: false
+      value_raw: "{'service_description': 'Ansible test', 'command_line': 'echo [1]'}"
+    state: "present"
+  register: __checkmk_var_result_brackets_modify
+  failed_when: not __checkmk_var_result_brackets_modify.changed
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Replace the parentheses inside the value with brackets. Again."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "custom_checks"
+    rule:
+      rule_id: "{{ __checkmk_var_result_parentheses_create.content.id }}"
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - parentheses in values"
+        disabled: false
+      value_raw: "{'service_description': 'Ansible test', 'command_line': 'echo [1]'}"
+    state: "present"
+  register: __checkmk_var_result_brackets_again
+  failed_when: __checkmk_var_result_brackets_again.changed
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Delete the rule with brackets inside the value."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "custom_checks"
+    rule:
+      rule_id: "{{ __checkmk_var_result_parentheses_create.content.id }}"
+    state: "absent"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule using plain label conditions."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      conditions:
+        host_labels:
+          - key: "cmk/site"
+            operator: "is"
+            value: "{{ outer_item.site }}"
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - plain label conditions"
+        disabled: false
+      value_raw: "{'magic': 0.8}"
+      location:
+        folder: "/"
+        position: "any"
+    state: "present"
+  register: __checkmk_var_result_labels_create
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule using plain label conditions. Again."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      conditions:
+        host_labels:
+          - key: "cmk/site"
+            operator: "is"
+            value: "{{ outer_item.site }}"
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - plain label conditions"
+        disabled: false
+      value_raw: "{'magic': 0.8}"
+      location:
+        folder: "/"
+        position: "any"
+    state: "present"
+  register: __checkmk_var_result_labels_again
+  failed_when: __checkmk_var_result_labels_again.changed
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Find the rules created from plain label conditions."
+  ansible.builtin.set_fact:
+    __checkmk_var_label_rules: "{{ lookup('checkmk.general.rules',
+        ruleset='checkgroup_parameters:filesystem',
+        comment_regex='Managed by Ansible',
+        server_url=checkmk_var_server_url,
+        site=outer_item.site,
+        api_user=checkmk_var_api_user,
+        api_secret=checkmk_var_api_secret,
+        validate_certs=False)
+        | selectattr('extensions.properties.description', 'equalto', 'Ansible test - plain label conditions')
+        | list }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Verify that plain label conditions did not create a duplicate."
+  ansible.builtin.assert:
+    that: __checkmk_var_label_rules | length == 1
+    fail_msg: "Expected exactly one rule, found {{ __checkmk_var_label_rules | length }}."
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Delete the rule using plain label conditions."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      rule_id: "{{ __checkmk_var_result_labels_create.content.id }}"
+    state: "absent"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Try to update a rule with a nonexistent rule_id."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      rule_id: "00000000-0000-0000-0000-000000000000"
+      properties:
+        description: "Ansible test - nonexistent rule_id"
+      value_raw: "{'magic': 0.8}"
+    state: "present"
+  register: __checkmk_var_result_missing_id
+  ignore_errors: true
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Verify the failure for a nonexistent rule_id."
+  ansible.builtin.assert:
+    that:
+      - __checkmk_var_result_missing_id is failed
+      - "'rule_id was not found' in __checkmk_var_result_missing_id.msg"
+    fail_msg: "Expected a failure for a nonexistent rule_id, got: {{ __checkmk_var_result_missing_id.msg }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Delete a rule with a nonexistent rule_id."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      rule_id: "00000000-0000-0000-0000-000000000000"
+    state: "absent"
+  register: __checkmk_var_result_missing_id_absent
+  failed_when: __checkmk_var_result_missing_id_absent.changed
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule without specifying a location."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - default location"
+        disabled: false
+      value_raw: "{'magic': 0.8}"
+    state: "present"
+  register: __checkmk_var_result_default_location
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Verify that a rule created at the default location is not moved."
+  ansible.builtin.assert:
+    that:
+      - __checkmk_var_result_default_location.changed
+      - "'move' not in __checkmk_var_result_default_location.msg | lower"
+    fail_msg: "Expected a plain create, got: {{ __checkmk_var_result_default_location.msg }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Delete the rule created at the default location."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      rule_id: "{{ __checkmk_var_result_default_location.content.id }}"
+    state: "absent"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule at the top of a folder."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - explicit position"
+        disabled: false
+      value_raw: "{'magic': 0.8}"
+      location:
+        folder: "/"
+        position: "top"
+    state: "present"
+  register: __checkmk_var_result_top_create
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Verify that an explicit position still moves the rule."
+  ansible.builtin.assert:
+    that: "'move' in __checkmk_var_result_top_create.msg | lower"
+    fail_msg: "Expected a move, got: {{ __checkmk_var_result_top_create.msg }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create a rule at the top of a folder. Again."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      properties:
+        comment: "Managed by Ansible"
+        description: "Ansible test - explicit position"
+        disabled: false
+      value_raw: "{'magic': 0.8}"
+      location:
+        folder: "/"
+        position: "top"
+    state: "present"
+  register: __checkmk_var_result_top_again
+  failed_when: __checkmk_var_result_top_again.changed
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Delete the rule at the top of the folder."
+  rule:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    ruleset: "checkgroup_parameters:filesystem"
+    rule:
+      rule_id: "{{ __checkmk_var_result_top_create.content.id }}"
+    state: "absent"


### PR DESCRIPTION
This PR was LLM-assisted. We will test it thoroughly and possibly adapt it in the process.
Human review is definitely the decisive factor here, we will only merge it, if it is well understood and valid.

## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #186

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- F1: rule module - Values are compared structurally, instead of rewriting
  parentheses to brackets, which silently ignored real changes to values
  containing brackets or parentheses inside strings, e.g. a command line.
  (``d731b032``)
- F2: rule module - ``host_labels`` and ``service_labels`` are translated to
  the label group format of Checkmk 2.3 and newer before comparing and sending,
  so the old syntax no longer creates a duplicate rule on every run.
  (``38cd1259``)
- F3: rule module - A nonexistent ``rule_id`` with ``state: present`` now fails
  as documented, instead of reporting an unchanged success. (``1f4cd5fb``)
- F4: rule module - Creating a rule at the default location no longer issues a
  superfluous move. (``f50c45cf``)
- F5: rule module - The examples use a value format that is valid on 2.3, 2.4
  and 2.5, and new notes cover the canonical value format, rules containing
  secrets and rule ordering. (``0994ce25``, ``6c3b9089``)
- F6: rule module - Normalizing a rule for comparison no longer modifies the
  desired and the current state in place. The data sent to the API is
  unchanged. (``fae197a9``)
- rule module - Regression tests for F1 to F4. Each of them was confirmed to
  fail against the pre-fix code. (``71d8c9ed``)

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.

Two judgement calls to confirm during review:

- J1: Rules containing secrets have to reference the password store. Such a
  reference is byte-stable on 2.3, 2.4 and 2.5, while an explicit password
  never is: the API masks it, and 2.3 and 2.4 regenerate its id on every read.
  Its exact form depends on the version and on the ruleset, so the notes tell
  users to copy the form their site returns.
- J2: Relative positions cannot be idempotent in general, and ``any`` is
  unsuitable for rulesets that are evaluated in first match order. Both are
  documented, together with the pattern that works: anchor the first rule and
  chain the others with ``position: after`` and ``neighbour``.
