### PR TITLE
Fix privilege escalation for MKP management

### DIFF
--- a/changelogs/fragments/mkps.yml
+++ b/changelogs/fragments/mkps.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Server role - Fix MKP management tasks failing when connecting as an
+    unprivileged user without ACL support, by using ``su`` to switch to the
+    site user instead of relying on ``become_user``.

--- a/roles/server/tasks/mkp.yml
+++ b/roles/server/tasks/mkp.yml
@@ -38,7 +38,6 @@
 
 - name: "{{ __site.name }}: Install MKP Packages."
   become: true
-  # become_user: "{{ __site.name }}"
   ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
   changed_when: __checkmk_server_mkp_install_output.rc == 0
   failed_when: __checkmk_server_mkp_install_output.rc != 0 and 'exists on the site' not in __checkmk_server_mkp_install_output.stderr
@@ -53,7 +52,6 @@
 
 - name: "{{ __site.name }}: Enable MKP Packages."
   become: true
-  # become_user: "{{ __site.name }}"
   ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_enable_output.rc == 0
   register: __checkmk_server_mkp_enable_output
@@ -67,7 +65,6 @@
 
 - name: "{{ __site.name }}: Disable MKP Packages."
   become: true
-  # become_user: "{{ __site.name }}"
   ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_disable_output.rc == 0
   register: __checkmk_server_mkp_disable_output
@@ -81,7 +78,6 @@
 
 - name: "{{ __site.name }}: Remove MKP Packages."
   become: true
-  # become_user: "{{ __site.name }}"
   ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_remove_output.rc == 0
   register: __checkmk_server_mkp_remove_output

--- a/roles/server/tasks/mkp.yml
+++ b/roles/server/tasks/mkp.yml
@@ -38,7 +38,7 @@
 
 - name: "{{ __site.name }}: Install MKP Packages."
   become: true
-  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
+  ansible.builtin.command: "su - {{ __site.name }} -s /bin/bash -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
   changed_when: __checkmk_server_mkp_install_output.rc == 0
   failed_when: __checkmk_server_mkp_install_output.rc != 0 and 'exists on the site' not in __checkmk_server_mkp_install_output.stderr
   register: __checkmk_server_mkp_install_output
@@ -52,7 +52,7 @@
 
 - name: "{{ __site.name }}: Enable MKP Packages."
   become: true
-  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
+  ansible.builtin.command: "su - {{ __site.name }} -s /bin/bash -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_enable_output.rc == 0
   register: __checkmk_server_mkp_enable_output
   loop: "{{ __site.mkp_packages }}"
@@ -65,7 +65,7 @@
 
 - name: "{{ __site.name }}: Disable MKP Packages."
   become: true
-  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
+  ansible.builtin.command: "su - {{ __site.name }} -s /bin/bash -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_disable_output.rc == 0
   register: __checkmk_server_mkp_disable_output
   loop: "{{ __site.mkp_packages }}"
@@ -78,7 +78,7 @@
 
 - name: "{{ __site.name }}: Remove MKP Packages."
   become: true
-  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
+  ansible.builtin.command: "su - {{ __site.name }} -s /bin/bash -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_remove_output.rc == 0
   register: __checkmk_server_mkp_remove_output
   loop: "{{ __site.mkp_packages }}"

--- a/roles/server/tasks/mkp.yml
+++ b/roles/server/tasks/mkp.yml
@@ -38,8 +38,8 @@
 
 - name: "{{ __site.name }}: Install MKP Packages."
   become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
+  # become_user: "{{ __site.name }}"
+  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp add {{ __checkmk_server_tmp_dir }}/{{ __mkp.name }}-{{ __mkp.version }}.mkp'"
   changed_when: __checkmk_server_mkp_install_output.rc == 0
   failed_when: __checkmk_server_mkp_install_output.rc != 0 and 'exists on the site' not in __checkmk_server_mkp_install_output.stderr
   register: __checkmk_server_mkp_install_output
@@ -53,8 +53,8 @@
 
 - name: "{{ __site.name }}: Enable MKP Packages."
   become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
+  # become_user: "{{ __site.name }}"
+  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp enable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_enable_output.rc == 0
   register: __checkmk_server_mkp_enable_output
   loop: "{{ __site.mkp_packages }}"
@@ -67,8 +67,8 @@
 
 - name: "{{ __site.name }}: Disable MKP Packages."
   become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
+  # become_user: "{{ __site.name }}"
+  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp disable {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_disable_output.rc == 0
   register: __checkmk_server_mkp_disable_output
   loop: "{{ __site.mkp_packages }}"
@@ -81,8 +81,8 @@
 
 - name: "{{ __site.name }}: Remove MKP Packages."
   become: true
-  become_user: "{{ __site.name }}"
-  ansible.builtin.command: "/bin/bash -l -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
+  # become_user: "{{ __site.name }}"
+  ansible.builtin.command: "su - {{ __site.name }} -c /bin/bash -l -c 'mkp remove {{ __mkp.name }} {{ __mkp.version }}'"
   changed_when: __checkmk_server_mkp_remove_output.rc == 0
   register: __checkmk_server_mkp_remove_output
   loop: "{{ __site.mkp_packages }}"


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #824 

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Remove `become_user: "{{ __site.name }}"`.
- Prefix command block with `su - {{ __site.name }} -c ` .
- This avoids the problem discussed in the aforementioned issue.
- [Background information](https://docs.ansible.com/projects/ansible-core/2.20/playbook_guide/playbooks_privilege_escalation.html#risks-of-becoming-an-unprivileged-user)

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
