### PR TITLE
add UID/GID as optional parameters for OMD create in server role

### DIFF
--- a/changelogs/fragments/changelog_role_sitecreate.yml
+++ b/changelogs/fragments/changelog_role_sitecreate.yml
@@ -1,4 +1,2 @@
-release_summary: "Add support in server role for UID and GID"
-
 minor_changes:
   - "Add support in server role for optional parameter OMD create UID and GID"

--- a/changelogs/fragments/changelog_role_sitecreate.yml
+++ b/changelogs/fragments/changelog_role_sitecreate.yml
@@ -1,0 +1,4 @@
+release_summary: "Add support in server role for UID and GID"
+
+minor_changes:
+  - "Add support in server role for optional parameter OMD create UID and GID"

--- a/roles/server/meta/argument_specs.yml
+++ b/roles/server/meta/argument_specs.yml
@@ -89,11 +89,11 @@ argument_specs:
                 type: "str"
                 description: "The value of the variable."
           uid:
-            type: "str"
+            type: "int"
             description: "The UID of the OMD site user"
             required: false
           gid:
-            type: "str"
+            type: "int"
             description: "The GID of the OMD site group"
             required: false
           mkp_packages:

--- a/roles/server/meta/argument_specs.yml
+++ b/roles/server/meta/argument_specs.yml
@@ -88,6 +88,14 @@ argument_specs:
               value:
                 type: "str"
                 description: "The value of the variable."
+          uid:
+            type: "str"
+            description: "The UID of the OMD site user"
+            required: false
+          gid:
+            type: "str"
+            description: "The GID of the OMD site group"
+            required: false
           mkp_packages:
             type: "list"
             elements: "dict"

--- a/roles/server/tasks/sites.yml
+++ b/roles/server/tasks/sites.yml
@@ -10,6 +10,8 @@
   ansible.builtin.shell: |
     set -o pipefail
     omd -V {{ item.version }}.{{ __checkmk_var_edition_id | lower }} create {{ item.name }}
+    {% if item.uid is defined %} --uid {{ item.uid }}{% endif %}
+    {% if item.gid is defined %} --gid {{ item.gid }}{% endif %}
   args:
     executable: /bin/bash
     creates: "/omd/sites/{{ item.name }}"


### PR DESCRIPTION
## Pull request type
- [x] Feature

## What is the current behavior?
Add optional parameters in the server role to specify the UID and GID (cfr. omd create commandline parameters)

## What is the new behavior?
If uid and/or gid is specified in the variable checkmk_server_sites, the uid and/or gid will be used during the creation of the site.
