### PR TITLE
Normalise a trailing slash on `server_url`.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -15,7 +15,7 @@ We encourage you - in accordance with Ansible Best Practices - to always use **F
   tasks:
     - name: "Run activation."
       checkmk.general.activation:
-        server_url: "http://myserver/"
+        server_url: "http://myserver"
         site: "mysite"
         api_user: "myuser"
         api_secret: "mysecret"
@@ -39,7 +39,7 @@ You can set default values for module parameters at the play level. These defaul
 - hosts: all
   module_defaults:
     group/checkmk.general.checkmk:
-      server_url: "http://myserver/"
+      server_url: "http://myserver"
       site: "mysite"
       api_user: "myuser"
       api_secret: "mysecret"
@@ -57,7 +57,7 @@ You can set default values for module parameters at the play level. These defaul
 You can also define these parameters as environment variables. Ansible will automatically pick them up. This is particularly useful for sensitive information like secrets.
 
 ```bash
-export CHECKMK_VAR_SERVER_URL="http://myserver/"
+export CHECKMK_VAR_SERVER_URL="http://myserver"
 export CHECKMK_VAR_SITE="mysite"
 export CHECKMK_VAR_API_USER="myuser"
 export CHECKMK_VAR_API_SECRET="mysecret"
@@ -69,7 +69,7 @@ Ansible can read variables from an INI file (e.g., `ansible.cfg` or a custom fil
 
 ```ini
 [checkmk]
-server_url = http://myserver/
+server_url = http://myserver
 site = mysite
 api_user = myuser
 api_secret = mysecret
@@ -113,7 +113,7 @@ This example demonstrates how to create or update a host in Checkmk:
   tasks:
     - name: "Create or update a host."
       checkmk.general.host:
-        server_url: "http://myserver/"
+        server_url: "http://myserver"
         site: "mysite"
         api_user: "myuser"
         api_secret: "mysecret"
@@ -165,7 +165,7 @@ To use the plugin, create a YAML file (e.g., `checkmk.yml`) with the following c
 
 ```yaml
 plugin: checkmk.general.checkmk
-server_url: "http://myserver/"
+server_url: "http://myserver"
 site: "mysite"
 api_user: "myuser"
 api_secret: "mysecret"

--- a/changelogs/fragments/server_url_normalization.yml
+++ b/changelogs/fragments/server_url_normalization.yml
@@ -1,0 +1,12 @@
+bugfixes:
+  - All modules, lookup plugins and the inventory plugin - Normalize a trailing
+    slash on ``server_url``. The documentation consistently showed the
+    ``https://myserver/`` form, which built request URLs with a doubled slash in
+    front of the site name. The Checkmk REST API tolerates that, but other
+    consumers of the same variable do not.
+
+minor_changes:
+  - Lookup plugins, Inventory plugin - ``CheckMKLookupAPI`` now takes
+    ``server_url`` and ``site`` separately and joins them itself, instead of
+    every caller building the site URL by hand. This only affects code importing
+    the class directly from ``module_utils``, not playbooks or roles.

--- a/playbooks/inventory/checkmk.yml
+++ b/playbooks/inventory/checkmk.yml
@@ -1,5 +1,5 @@
 plugin: checkmk.general.checkmk
-server_url: "http://myserver/"
+server_url: "http://myserver"
 site: "mysite"
 api_user: "myuser"
 api_secret: "mysecret"

--- a/playbooks/usecases/env-vars-from-ini-variables.yml
+++ b/playbooks/usecases/env-vars-from-ini-variables.yml
@@ -6,7 +6,7 @@
 # You need the following section in your `ansible.cfg`:
 #
 # [checkmk_lookup]
-# server_url = https://myserver/
+# server_url = https://myserver
 # site = mysite
 # api_user = myuser
 # api_secret = mysecret

--- a/playbooks/vars/auth.yml
+++ b/playbooks/vars/auth.yml
@@ -1,6 +1,6 @@
 ---
 # Provice the URL and credentials to your Checkmk site here #
-checkmk_var_server_url: "http://myserver/"
+checkmk_var_server_url: "http://myserver"
 checkmk_var_site: "mysite"
 checkmk_var_api_user: "myuser"
 checkmk_var_api_secret: "mysecret"

--- a/plugins/inventory/checkmk.py
+++ b/plugins/inventory/checkmk.py
@@ -108,7 +108,7 @@ EXAMPLES = """
 # Group all hosts based on both tag groups and sites
 # and update ansible_host with the ip address from Checkmk:
 plugin: checkmk.general.checkmk
-server_url: "http://myserver/"
+server_url: "http://myserver"
 site: "mysite"
 api_user: "myuser"
 api_secret: "mysecret"
@@ -305,7 +305,8 @@ class InventoryModule(BaseInventoryPlugin):
             display.vvv("Excluding hosts with tags: %s" % self.exclude_tags)
 
         api = CheckMKLookupAPI(
-            site_url=self.get_option("server_url") + "/" + self.get_option("site"),
+            server_url=self.get_option("server_url"),
+            site=self.get_option("site"),
             api_auth_type=self.api_auth_type,
             api_auth_cookie=self.api_auth_cookie,
             api_user=self.get_option("api_user"),

--- a/plugins/lookup/activation.py
+++ b/plugins/lookup/activation.py
@@ -44,7 +44,7 @@ EXAMPLES = """
   vars:
     activation: "{{ lookup('checkmk.general.activation',
                    'my_activation_id',
-                   server_url='https://myserver/',
+                   server_url='https://myserver',
                    site='mysite',
                    api_user='myuser',
                    api_secret='mysecret',
@@ -64,7 +64,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Activation status is {{ activation }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -101,10 +101,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/activations.py
+++ b/plugins/lookup/activations.py
@@ -37,7 +37,7 @@ EXAMPLES = """
     msg: "Activations: {{ activations }}"
   vars:
     activations: "{{ lookup('checkmk.general.activations',
-                   server_url='https://myserver/',
+                   server_url='https://myserver',
                    site='mysite',
                    api_user='myuser',
                    api_secret='mysecret',
@@ -57,7 +57,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Activations: {{ activations }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -94,10 +94,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/bakery.py
+++ b/plugins/lookup/bakery.py
@@ -35,7 +35,7 @@ EXAMPLES = """
     msg: "Bakery status is {{ bakery }}"
   vars:
     bakery: "{{ lookup('checkmk.general.bakery',
-                   server_url='https://myserver/',
+                   server_url='https://myserver',
                    site='mysite',
                    api_user='myuser',
                    api_secret='mysecret',
@@ -55,7 +55,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Bakery status is {{ bakery }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -94,7 +94,8 @@ class LookupModule(LookupBase):
         ret = []
 
         api = CheckMKLookupAPI(
-            site_url=server_url + "/" + site,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/folder.py
+++ b/plugins/lookup/folder.py
@@ -45,7 +45,7 @@ EXAMPLES = """
     attributes: "{{
       lookup('checkmk.general.folder',
              '~tests',
-             server_url='https://myserver/',
+             server_url='https://myserver',
              site='mysite',
              api_user='myuser',
              api_secret='mysecret',
@@ -59,7 +59,7 @@ EXAMPLES = """
   loop: "{{
            lookup('checkmk.general.folder',
                   '~tests', '~snmp',
-                  server_url='https://myserver/',
+                  server_url='https://myserver',
                   site='mysite',
                   api_user='myuser',
                   api_secret='mysecret',
@@ -82,7 +82,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Extended attributes of folder /tests: {{ attributes.extensions }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -119,10 +119,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/folders.py
+++ b/plugins/lookup/folders.py
@@ -58,7 +58,7 @@ EXAMPLES = """
     lookup('checkmk.general.folders',
         '~',
         recursive=True,
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -77,7 +77,7 @@ EXAMPLES = """
                      '~tests',
                      show_hosts=True,
                      recursive=True,
-                     server_url='https://myserver/',
+                     server_url='https://myserver',
                      site='mysite',
                      api_user='myuser',
                      api_secret='mysecret',
@@ -101,7 +101,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Folder: {{ item.id }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -145,10 +145,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/host.py
+++ b/plugins/lookup/host.py
@@ -51,7 +51,7 @@ EXAMPLES = """
     attributes: "{{
                     lookup('checkmk.general.host',
                         'myhost',
-                        server_url='https://myserver/',
+                        server_url='https://myserver',
                         site='mysite',
                         api_user='myuser',
                         api_secret='mysecret',
@@ -67,7 +67,7 @@ EXAMPLES = """
                     lookup('checkmk.general.host',
                         'myhost',
                         effective_attributes=True,
-                        server_url='https://myserver/',
+                        server_url='https://myserver',
                         site='mysite',
                         api_user='myuser',
                         api_secret='mysecret',
@@ -88,7 +88,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Attributes of myhost: {{ attributes }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -125,10 +125,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/hosts.py
+++ b/plugins/lookup/hosts.py
@@ -46,7 +46,7 @@ EXAMPLES = """
     msg: "Host {{ item.id }} is in folder {{ item.extensions.folder }}"
   loop: "{{
     lookup('checkmk.general.hosts',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -62,7 +62,7 @@ EXAMPLES = """
   loop: "{{
     lookup('checkmk.general.hosts',
         effective_attributes=True,
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -85,7 +85,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Host {{ item.id }} is in folder {{ item.extensions.folder }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -124,10 +124,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/ldap_connection.py
+++ b/plugins/lookup/ldap_connection.py
@@ -45,7 +45,7 @@ EXAMPLES = """
     ldap_config: "{{
       lookup('checkmk.general.ldap_connection',
         'my_ldap_connection',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -66,7 +66,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "LDAP connection: {{ ldap_config }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -105,10 +105,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             # api_auth_type=api_auth_type,
             # api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/ldap_connections.py
+++ b/plugins/lookup/ldap_connections.py
@@ -37,7 +37,7 @@ EXAMPLES = """
     msg: "LDAP connection {{ item.id }}: {{ item.extensions }}"
   loop: "{{
     lookup('checkmk.general.ldap_connections',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -60,7 +60,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "LDAP connection {{ item.id }}: {{ item.extensions }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -102,10 +102,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             # api_auth_type=api_auth_type,
             # api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/role.py
+++ b/plugins/lookup/role.py
@@ -46,7 +46,7 @@ EXAMPLES = """
     role_config: "{{
       lookup('checkmk.general.role',
         'host_manager',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -67,7 +67,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Role host_manager: {{ role_config }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -103,10 +103,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/roles.py
+++ b/plugins/lookup/roles.py
@@ -38,7 +38,7 @@ EXAMPLES = """
     msg: "Role {{ item.id }}: {{ item.extensions }}"
   loop: "{{
     lookup('checkmk.general.roles',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -61,7 +61,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Role {{ item.id }}: {{ item.extensions }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -99,10 +99,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/rule.py
+++ b/plugins/lookup/rule.py
@@ -49,7 +49,7 @@ EXAMPLES = """
     rule: "{{
       lookup('checkmk.general.rule',
         rule_id='a9285bc1-dcaf-45e0-a3ba-ad398ef06a49',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -70,7 +70,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Rule: {{ rule }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -107,10 +107,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/rules.py
+++ b/plugins/lookup/rules.py
@@ -67,7 +67,7 @@ EXAMPLES = """
   loop: "{{
     lookup('checkmk.general.rules',
         ruleset='host_groups',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -84,7 +84,7 @@ EXAMPLES = """
     lookup('checkmk.general.rules',
         ruleset='host_groups',
         folder_regex='^/test$',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -102,7 +102,7 @@ EXAMPLES = """
         ruleset='active_checks:http',
         description_regex='myservice.*',
         comment_regex='Managed by Ansible',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -125,7 +125,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Rule {{ item.id }}: {{ item.extensions }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -169,10 +169,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/ruleset.py
+++ b/plugins/lookup/ruleset.py
@@ -49,7 +49,7 @@ EXAMPLES = """
     ruleset: "{{
       lookup('checkmk.general.ruleset',
         ruleset='host_groups',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -70,7 +70,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Ruleset host_groups has {{ ruleset.number_of_rules }} rules."
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -107,10 +107,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/rulesets.py
+++ b/plugins/lookup/rulesets.py
@@ -70,7 +70,7 @@ EXAMPLES = """
     lookup('checkmk.general.rulesets',
       regex='file',
       rulesets_used=True,
-      server_url='https://myserver/',
+      server_url='https://myserver',
       site='mysite',
       api_user='myuser',
       api_secret='mysecret',
@@ -88,7 +88,7 @@ EXAMPLES = """
       regex='',
       rulesets_deprecated=True,
       rulesets_used=True,
-      server_url='https://myserver/',
+      server_url='https://myserver',
       site='mysite',
       api_user='myuser',
       api_secret='mysecret',
@@ -111,7 +111,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Ruleset {{ item.extensions.name }} is deprecated."
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -152,10 +152,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/site.py
+++ b/plugins/lookup/site.py
@@ -45,7 +45,7 @@ EXAMPLES = """
     site_config: "{{
       lookup('checkmk.general.site',
         'myremotesite',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -66,7 +66,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Site myremotesite: {{ site_config }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -102,10 +102,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/sites.py
+++ b/plugins/lookup/sites.py
@@ -37,7 +37,7 @@ EXAMPLES = """
     msg: "Site {{ item.id }}: {{ item.extensions }}"
   loop: "{{
     lookup('checkmk.general.sites',
-        server_url='https://myserver/',
+        server_url='https://myserver',
         site='mysite',
         api_user='myuser',
         api_secret='mysecret',
@@ -60,7 +60,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Site {{ item.id }}: {{ item.extensions }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -99,10 +99,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/lookup/version.py
+++ b/plugins/lookup/version.py
@@ -32,7 +32,7 @@ EXAMPLES = """
     msg: "Server version is {{ version }}"
   vars:
     version: "{{ lookup('checkmk.general.version',
-                   server_url='https://myserver/',
+                   server_url='https://myserver',
                    site='mysite',
                    api_user='myuser',
                    api_secret='mysecret',
@@ -52,7 +52,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "Server version is {{ version }}"
   vars:
-    checkmk_var_server_url: "https://myserver/"
+    checkmk_var_server_url: "https://myserver"
     checkmk_var_site: "mysite"
     checkmk_var_api_user: "myuser"
     checkmk_var_api_secret: "mysecret"
@@ -88,10 +88,9 @@ class LookupModule(LookupBase):
         api_secret = self.get_option("api_secret")
         validate_certs = self.get_option("validate_certs")
 
-        site_url = server_url + "/" + site
-
         api = CheckMKLookupAPI(
-            site_url=site_url,
+            server_url=server_url,
+            site=site,
             api_auth_type=api_auth_type,
             api_auth_cookie=api_auth_cookie,
             api_user=api_user,

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -31,7 +31,11 @@ class CheckmkAPI:
         self.module = module
         self.logger = logger
         self.params = self.module.params
-        server = self.params.get("server_url")
+        # Tolerate a trailing slash on server_url. Without it, a server_url
+        # ending in a slash produces a doubled slash in front of the site name.
+        # The Checkmk API happens to accept that, but other consumers of the
+        # same variable are not as forgiving.
+        server = (self.params.get("server_url") or "").rstrip("/")
         site = self.params.get("site")
         self.url = "%s/%s/check_mk/api/1.0" % (server, site)
 

--- a/plugins/module_utils/lookup_api.py
+++ b/plugins/module_utils/lookup_api.py
@@ -29,7 +29,8 @@ class CheckMKLookupAPI:
 
     def __init__(
         self,
-        site_url,
+        server_url,
+        site,
         api_auth_type="bearer",
         api_auth_cookie=None,
         api_user=None,
@@ -42,8 +43,12 @@ class CheckMKLookupAPI:
         }
         self.cookies = {}
 
-        self.site_url = site_url
-        self.url = "%s/check_mk/api/1.0" % site_url
+        # Joining here rather than in every caller keeps the trailing-slash
+        # handling in one place. rstrip() and not urljoin(): urljoin treats the
+        # last path segment as a document, so a server_url with a path prefix
+        # and no trailing slash would lose that prefix.
+        self.site_url = "%s/%s" % (server_url.rstrip("/"), site)
+        self.url = "%s/check_mk/api/1.0" % self.site_url
         self.validate_certs = validate_certs
         # Bearer Authentication: "Bearer USERNAME PASSWORD"
         if api_auth_type == "bearer":

--- a/plugins/modules/activation.py
+++ b/plugins/modules/activation.py
@@ -67,7 +67,7 @@ EXAMPLES = r"""
 
 - name: "Activate changes on all sites."
   checkmk.general.activation:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -75,7 +75,7 @@ EXAMPLES = r"""
 
 - name: "Activate changes on all sites and wait for completion."
   checkmk.general.activation:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -88,7 +88,7 @@ EXAMPLES = r"""
 
 - name: "Activate changes on a specific site."
   checkmk.general.activation:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -98,7 +98,7 @@ EXAMPLES = r"""
 
 - name: "Activate changes on multiple specific sites."
   checkmk.general.activation:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -115,7 +115,7 @@ EXAMPLES = r"""
 
 - name: "Activate changes including changes made by other users."
   checkmk.general.activation:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -124,7 +124,7 @@ EXAMPLES = r"""
 
 - name: "Activate changes including foreign changes and wait for completion."
   checkmk.general.activation:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -145,7 +145,7 @@ EXAMPLES = r"""
   checkmk.general.activation:
   run_once: true
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/aux_tag.py
+++ b/plugins/modules/aux_tag.py
@@ -68,7 +68,7 @@ EXAMPLES = r"""
 
 - name: "Create an auxiliary tag."
   checkmk.general.aux_tag:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -78,7 +78,7 @@ EXAMPLES = r"""
 
 - name: "Create an auxiliary tag with a topic and help text."
   checkmk.general.aux_tag:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -90,7 +90,7 @@ EXAMPLES = r"""
 
 - name: "Update the title of an existing auxiliary tag."
   checkmk.general.aux_tag:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -104,7 +104,7 @@ EXAMPLES = r"""
 
 - name: "Delete an auxiliary tag."
   checkmk.general.aux_tag:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -126,7 +126,7 @@ EXAMPLES = r"""
     title: "HTTPS"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/bakery.py
+++ b/plugins/modules/bakery.py
@@ -72,7 +72,7 @@ EXAMPLES = r"""
 
 - name: "Bake all agents without signing."
   checkmk.general.bakery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -80,7 +80,7 @@ EXAMPLES = r"""
 
 - name: "Sign all agents with an existing signing key."
   checkmk.general.bakery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -90,7 +90,7 @@ EXAMPLES = r"""
 
 - name: "Bake and sign all agents in one step."
   checkmk.general.bakery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -111,7 +111,7 @@ EXAMPLES = r"""
   checkmk.general.bakery:
     state: "baked"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/contact_group.py
+++ b/plugins/modules/contact_group.py
@@ -76,7 +76,7 @@ EXAMPLES = r"""
 
 - name: "Create a single contact group."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -86,7 +86,7 @@ EXAMPLES = r"""
 
 - name: "Update the title of a single contact group."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -96,7 +96,7 @@ EXAMPLES = r"""
 
 - name: "Delete a single contact group."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -112,7 +112,7 @@ EXAMPLES = r"""
 
 - name: "Create multiple contact groups."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -127,7 +127,7 @@ EXAMPLES = r"""
 
 - name: "Delete multiple contact groups."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -145,7 +145,7 @@ EXAMPLES = r"""
 
 - name: "Create a single contact group assigned to a customer."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -156,7 +156,7 @@ EXAMPLES = r"""
 
 - name: "Create multiple contact groups assigned to a customer."
   checkmk.general.contact_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -183,7 +183,7 @@ EXAMPLES = r"""
     title: "My Contact Group"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"
@@ -500,7 +500,7 @@ def run_module():
     }
 
     base_url = "%s/%s/check_mk/api/1.0" % (
-        module.params.get("server_url", ""),
+        module.params.get("server_url", "").rstrip("/"),
         module.params.get("site", ""),
     )
 

--- a/plugins/modules/dcd.py
+++ b/plugins/modules/dcd.py
@@ -153,7 +153,7 @@ EXAMPLES = r"""
 
 - name: "Create a DCD connection with a creation rule."
   checkmk.general.dcd:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -174,7 +174,7 @@ EXAMPLES = r"""
 
 - name: "Create a DCD connection with host attributes set on created hosts."
   checkmk.general.dcd:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -200,7 +200,7 @@ EXAMPLES = r"""
 
 - name: "Create a fully configured piggyback DCD with custom timing and host matching."
   checkmk.general.dcd:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -237,7 +237,7 @@ EXAMPLES = r"""
 
 - name: "Delete a DCD connection."
   checkmk.general.dcd:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -263,7 +263,7 @@ EXAMPLES = r"""
       site: "mysite"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -111,7 +111,7 @@ EXAMPLES = r"""
 
 - name: "Add newly discovered services on a host."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -120,7 +120,7 @@ EXAMPLES = r"""
 
 - name: "Add newly discovered services, update labels, and remove vanished services on a host."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -129,7 +129,7 @@ EXAMPLES = r"""
 
 - name: "Remove all vanished services from a host."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -138,7 +138,7 @@ EXAMPLES = r"""
 
 - name: "Discover only host labels on a host."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -147,7 +147,7 @@ EXAMPLES = r"""
 
 - name: "Discover only service labels on a host."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -156,7 +156,7 @@ EXAMPLES = r"""
 
 - name: "Move all undecided services to monitored on a host."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -169,7 +169,7 @@ EXAMPLES = r"""
 
 - name: "Add newly discovered services on multiple hosts."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -180,7 +180,7 @@ EXAMPLES = r"""
 
 - name: "Add newly discovered services, update labels, and remove vanished services on multiple hosts."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -191,7 +191,7 @@ EXAMPLES = r"""
 
 - name: "Bulk discovery with a timeout of 30 seconds."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -203,7 +203,7 @@ EXAMPLES = r"""
 
 - name: "Bulk discovery processing 3 hosts at a time."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -219,7 +219,7 @@ EXAMPLES = r"""
 
 - name: "Start bulk discovery without waiting for completion."
   checkmk.general.discovery:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -243,7 +243,7 @@ EXAMPLES = r"""
     host_name: "myhost"
     state: "new"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/downtime.py
+++ b/plugins/modules/downtime.py
@@ -115,7 +115,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a host downtime starting now, ending in 2 hours."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -125,7 +125,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a host downtime with a comment, starting now, ending in 2 hours."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -136,7 +136,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a host downtime using absolute start and end times."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -147,7 +147,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a host downtime starting in 30 minutes and lasting 4 hours."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -164,7 +164,7 @@ EXAMPLES = r"""
 
 - name: "Remove all downtimes from a host."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -173,7 +173,7 @@ EXAMPLES = r"""
 
 - name: "Remove only host downtimes matching a specific comment."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -187,7 +187,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a downtime for a single service on a host."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -200,7 +200,7 @@ EXAMPLES = r"""
 
 - name: "Schedule downtimes for multiple services on a host using absolute times."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -218,7 +218,7 @@ EXAMPLES = r"""
 
 - name: "Remove all downtimes for specific services on a host."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -230,7 +230,7 @@ EXAMPLES = r"""
 
 - name: "Remove service downtimes matching a specific comment."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -247,7 +247,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a host downtime for multiple hosts."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -262,7 +262,7 @@ EXAMPLES = r"""
 
 - name: "Remove host downtimes for multiple hosts."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -287,7 +287,7 @@ EXAMPLES = r"""
 
 - name: "Schedule a flexible host downtime triggered by a non-OK state."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -306,7 +306,7 @@ EXAMPLES = r"""
 
 - name: "Force a new host downtime even if one with the same comment already exists."
   checkmk.general.downtime:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -332,7 +332,7 @@ EXAMPLES = r"""
     end_after:
       hours: 2
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"
@@ -641,7 +641,7 @@ def run_module():
     }
 
     base_url = "%s/%s/check_mk/api/1.0" % (
-        module.params.get("server_url"),
+        (module.params.get("server_url") or "").rstrip("/"),
         module.params.get("site"),
     )
 

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -103,7 +103,7 @@ EXAMPLES = r"""
 
 - name: "Create a folder."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -113,7 +113,7 @@ EXAMPLES = r"""
 
 - name: "Create a nested folder."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -123,7 +123,7 @@ EXAMPLES = r"""
 
 - name: "Delete a folder."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -138,7 +138,7 @@ EXAMPLES = r"""
 
 - name: "Create a folder and pin its hosts to a specific monitoring site."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -150,7 +150,7 @@ EXAMPLES = r"""
 
 - name: "Create a folder with host tags set."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -167,7 +167,7 @@ EXAMPLES = r"""
 
 - name: "Update specific attributes on a folder without touching others."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -178,7 +178,7 @@ EXAMPLES = r"""
 
 - name: "Remove specific attributes from a folder."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -189,7 +189,7 @@ EXAMPLES = r"""
 
 - name: "Remove multiple attributes from a folder."
   checkmk.general.folder:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -214,7 +214,7 @@ EXAMPLES = r"""
     name: "My Folder"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -131,7 +131,7 @@ EXAMPLES = r"""
 
 - name: "Create a host."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -141,7 +141,7 @@ EXAMPLES = r"""
 
 - name: "Delete a host."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -156,7 +156,7 @@ EXAMPLES = r"""
 
 - name: "Create a host with an IP address and alias."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -169,7 +169,7 @@ EXAMPLES = r"""
 
 - name: "Create a host pinned to a specific monitoring site."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -185,7 +185,7 @@ EXAMPLES = r"""
 
 - name: "Update specific attributes without touching others."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -196,7 +196,7 @@ EXAMPLES = r"""
 
 - name: "Set a custom tag on a host (note the 'tag_' prefix)."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -207,7 +207,7 @@ EXAMPLES = r"""
 
 - name: "Remove specific attributes from a host."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -224,7 +224,7 @@ EXAMPLES = r"""
 
 - name: "Move a host to a different folder."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -238,7 +238,7 @@ EXAMPLES = r"""
 
 - name: "Create a cluster host."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -252,7 +252,7 @@ EXAMPLES = r"""
 
 - name: "Add a node to an existing cluster host."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -263,7 +263,7 @@ EXAMPLES = r"""
 
 - name: "Remove a node from a cluster host."
   checkmk.general.host:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -287,7 +287,7 @@ EXAMPLES = r"""
     folder: "/"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/host_group.py
+++ b/plugins/modules/host_group.py
@@ -67,7 +67,7 @@ EXAMPLES = r"""
 
 - name: "Create a host group."
   checkmk.general.host_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -77,7 +77,7 @@ EXAMPLES = r"""
 
 - name: "Delete a host group."
   checkmk.general.host_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -90,7 +90,7 @@ EXAMPLES = r"""
 
 - name: "Create several host groups at once."
   checkmk.general.host_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -105,7 +105,7 @@ EXAMPLES = r"""
 
 - name: "Delete several host groups at once."
   checkmk.general.host_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -120,7 +120,7 @@ EXAMPLES = r"""
 
 - name: "Create a host group and assign it to a customer (Checkmk Ultimate with multi-tenancy (CME) only)."
   checkmk.general.host_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -144,7 +144,7 @@ EXAMPLES = r"""
     title: "Linux Servers"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"
@@ -466,7 +466,7 @@ def run_module():
     }
 
     base_url = "%s/%s/check_mk/api/1.0" % (
-        module.params.get("server_url", ""),
+        module.params.get("server_url", "").rstrip("/"),
         module.params.get("site", ""),
     )
 

--- a/plugins/modules/ldap.py
+++ b/plugins/modules/ldap.py
@@ -601,7 +601,7 @@ EXAMPLES = r"""
 
 - name: "Create an LDAP connection with minimal configuration."
   checkmk.general.ldap:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -618,7 +618,7 @@ EXAMPLES = r"""
 
 - name: "Delete an LDAP connection."
   checkmk.general.ldap:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -633,7 +633,7 @@ EXAMPLES = r"""
 
 - name: "Create a fully configured LDAP connection."
   checkmk.general.ldap:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -691,7 +691,7 @@ EXAMPLES = r"""
 
 - name: "Update the comment on all existing LDAP connections."
   checkmk.general.ldap:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -702,7 +702,7 @@ EXAMPLES = r"""
       general_properties:
         comment: "Managed by Ansible"
   loop: "{{ lookup('checkmk.general.ldap_connections',
-                        server_url='https://myserver/',
+                        server_url='https://myserver',
                         site='mysite',
                         api_user='myuser',
                         api_secret='mysecret',
@@ -733,7 +733,7 @@ EXAMPLES = r"""
           ldap_server: "ldap.example.com"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/notification.py
+++ b/plugins/modules/notification.py
@@ -44,7 +44,7 @@ EXAMPLES = r"""
 
 - name: "Create an email notification rule"
   checkmk.general.notification:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -69,7 +69,7 @@ EXAMPLES = r"""
 
 - name: "Create a Slack notification rule"
   checkmk.general.notification:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -92,7 +92,7 @@ EXAMPLES = r"""
 
 - name: "Create a Microsoft Teams notification rule"
   checkmk.general.notification:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -120,7 +120,7 @@ EXAMPLES = r"""
 #       Keys absent from rule_config will not be modified in the existing rule.
 - name: "Update a notification rule"
   checkmk.general.notification:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -140,7 +140,7 @@ EXAMPLES = r"""
 
 - name: "Delete a notification rule by rule_id"
   checkmk.general.notification:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -151,7 +151,7 @@ EXAMPLES = r"""
 #       Use rule_id for unambiguous deletion.
 - name: "Delete a notification rule by description"
   checkmk.general.notification:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -185,7 +185,7 @@ EXAMPLES = r"""
           state: "enabled"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/password.py
+++ b/plugins/modules/password.py
@@ -95,7 +95,7 @@ EXAMPLES = r"""
 
 - name: "Create a password."
   checkmk.general.password:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -111,7 +111,7 @@ EXAMPLES = r"""
 
 - name: "Create a password with all optional fields."
   checkmk.general.password:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -129,7 +129,7 @@ EXAMPLES = r"""
 
 - name: "Delete a password."
   checkmk.general.password:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -154,7 +154,7 @@ EXAMPLES = r"""
     state: "present"
   no_log: true
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -104,7 +104,7 @@ EXAMPLES = r"""
 
 - name: "Create a custom monitoring role."
   checkmk.general.role:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -115,7 +115,7 @@ EXAMPLES = r"""
 
 - name: "Create a custom role with tailored permissions."
   checkmk.general.role:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -131,7 +131,7 @@ EXAMPLES = r"""
 
 - name: "Delete a custom role."
   checkmk.general.role:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -144,7 +144,7 @@ EXAMPLES = r"""
 
 - name: "Update permissions on an existing custom role."
   checkmk.general.role:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -155,7 +155,7 @@ EXAMPLES = r"""
 
 - name: "Modify permissions on the built-in user role."
   checkmk.general.role:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -180,7 +180,7 @@ EXAMPLES = r"""
     based_on: "user"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -130,7 +130,7 @@ EXAMPLES = r"""
 
 - name: "Create a rule at the top of the main folder."
   checkmk.general.rule:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -161,7 +161,7 @@ EXAMPLES = r"""
 
 - name: "Delete a rule by ID."
   checkmk.general.rule:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -176,7 +176,7 @@ EXAMPLES = r"""
 
 - name: "Create a rule and place it after an existing rule."
   checkmk.general.rule:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -206,7 +206,7 @@ EXAMPLES = r"""
 
 - name: "Create a rule matching a host label."
   checkmk.general.rule:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -229,7 +229,7 @@ EXAMPLES = r"""
 
 - name: "Create a rule with combined label group conditions (Checkmk >= 2.3.0)."
   checkmk.general.rule:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -261,7 +261,7 @@ EXAMPLES = r"""
 
 - name: "Delete all rules in a ruleset that match a certain comment."
   checkmk.general.rule:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -273,7 +273,7 @@ EXAMPLES = r"""
            lookup('checkmk.general.rules',
              ruleset='checkgroup_parameters:memory_percentage_used',
              comment_regex='Managed by Ansible',
-             server_url='https://myserver/',
+             server_url='https://myserver',
              site='mysite',
              api_user='myuser',
              api_secret='mysecret',
@@ -305,7 +305,7 @@ EXAMPLES = r"""
         position: "bottom"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/service_group.py
+++ b/plugins/modules/service_group.py
@@ -76,7 +76,7 @@ EXAMPLES = r"""
 
 - name: "Create a service group."
   checkmk.general.service_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -86,7 +86,7 @@ EXAMPLES = r"""
 
 - name: "Delete a service group."
   checkmk.general.service_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -99,7 +99,7 @@ EXAMPLES = r"""
 
 - name: "Create several service groups at once."
   checkmk.general.service_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -114,7 +114,7 @@ EXAMPLES = r"""
 
 - name: "Delete several service groups at once."
   checkmk.general.service_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -129,7 +129,7 @@ EXAMPLES = r"""
 
 - name: "Create a service group and assign it to a customer (Checkmk Ultimate with multi-tenancy (CME) only)."
   checkmk.general.service_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -153,7 +153,7 @@ EXAMPLES = r"""
     title: "Web Services"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"
@@ -443,7 +443,7 @@ def run_module():
     }
 
     base_url = "%s/%s/check_mk/api/1.0" % (
-        module.params.get("server_url", ""),
+        module.params.get("server_url", "").rstrip("/"),
         module.params.get("site", ""),
     )
 

--- a/plugins/modules/site.py
+++ b/plugins/modules/site.py
@@ -39,7 +39,7 @@ EXAMPLES = r"""
 
 - name: "Add a remote site with configuration replication."
   checkmk.general.site:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -69,7 +69,7 @@ EXAMPLES = r"""
 
 - name: "Delete a remote site connection."
   checkmk.general.site:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -82,7 +82,7 @@ EXAMPLES = r"""
 
 - name: "Log into a remote site to enable configuration replication."
   checkmk.general.site:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -95,7 +95,7 @@ EXAMPLES = r"""
 
 - name: "Log out from a remote site."
   checkmk.general.site:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -116,7 +116,7 @@ EXAMPLES = r"""
     site_id: "myremotesite"
     state: "absent"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/tag_group.py
+++ b/plugins/modules/tag_group.py
@@ -103,7 +103,7 @@ EXAMPLES = r"""
 
 - name: "Create a tag group."
   checkmk.general.tag_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -122,7 +122,7 @@ EXAMPLES = r"""
 
 - name: "Create a tag group with auxiliary tags assigned to its values."
   checkmk.general.tag_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -145,7 +145,7 @@ EXAMPLES = r"""
 
 - name: "Delete a tag group."
   checkmk.general.tag_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -160,7 +160,7 @@ EXAMPLES = r"""
 
 - name: "Delete a tag group and repair affected hosts automatically."
   checkmk.general.tag_group:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -186,7 +186,7 @@ EXAMPLES = r"""
         title: "Datacenter 1"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/timeperiod.py
+++ b/plugins/modules/timeperiod.py
@@ -69,7 +69,7 @@ EXAMPLES = r"""
 
 - name: "Create a time period covering business hours on weekdays."
   checkmk.general.timeperiod:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -100,7 +100,7 @@ EXAMPLES = r"""
 
 - name: "Create a time period using 'all' as a shorthand for every day."
   checkmk.general.timeperiod:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -115,7 +115,7 @@ EXAMPLES = r"""
 
 - name: "Create a time period with holiday exceptions."
   checkmk.general.timeperiod:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -139,7 +139,7 @@ EXAMPLES = r"""
 
 - name: "Create a time period that excludes another time period."
   checkmk.general.timeperiod:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -156,7 +156,7 @@ EXAMPLES = r"""
 
 - name: "Delete a time period."
   checkmk.general.timeperiod:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -183,7 +183,7 @@ EXAMPLES = r"""
             end: "17:00"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -177,7 +177,7 @@ EXAMPLES = r"""
 
 - name: "Create a standard user with password authentication."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -192,7 +192,7 @@ EXAMPLES = r"""
 
 - name: "Create an automation user for API access."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -206,7 +206,7 @@ EXAMPLES = r"""
 
 - name: "Delete a user."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -219,7 +219,7 @@ EXAMPLES = r"""
 
 - name: "Create a user assigned to contact groups."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -241,7 +241,7 @@ EXAMPLES = r"""
 
 - name: "Create a user with all available options."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -271,7 +271,7 @@ EXAMPLES = r"""
 
 - name: "Reset a user's password."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -286,7 +286,7 @@ EXAMPLES = r"""
 
 - name: "Create a user and assign them to a customer (Checkmk Ultimate with multi-tenancy (CME) only)."
   checkmk.general.user:
-    server_url: "https://myserver/"
+    server_url: "https://myserver"
     site: "mysite"
     api_user: "myuser"
     api_secret: "mysecret"
@@ -315,7 +315,7 @@ EXAMPLES = r"""
     password: "initial_password"
     state: "present"
   environment:
-    CHECKMK_VAR_SERVER_URL: "https://myserver/"
+    CHECKMK_VAR_SERVER_URL: "https://myserver"
     CHECKMK_VAR_SITE: "mysite"
     CHECKMK_VAR_API_USER: "myuser"
     CHECKMK_VAR_API_SECRET: "mysecret"

--- a/tests/unit/plugins/inventory/test_checkmk.py
+++ b/tests/unit/plugins/inventory/test_checkmk.py
@@ -63,9 +63,8 @@ def test_populate_allgroups(inventory, mocker):
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
 
     api = CheckMKLookupAPI(
-        site_url=inventory.get_option("server_url")
-        + "/"
-        + inventory.get_option("site"),
+        server_url=inventory.get_option("server_url"),
+        site=inventory.get_option("site"),
         api_user=inventory.get_option("api_user"),
         api_secret=inventory.get_option("api_secret"),
         validate_certs=inventory.get_option("validate_certs"),
@@ -151,9 +150,8 @@ def test_populate_nogroups(inventory, mocker):
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
 
     api = CheckMKLookupAPI(
-        site_url=inventory.get_option("server_url")
-        + "/"
-        + inventory.get_option("site"),
+        server_url=inventory.get_option("server_url"),
+        site=inventory.get_option("site"),
         api_user=inventory.get_option("api_user"),
         api_secret=inventory.get_option("api_secret"),
         validate_certs=inventory.get_option("validate_certs"),
@@ -195,7 +193,8 @@ def fresh_inventory():
 @pytest.fixture()
 def api():
     return CheckMKLookupAPI(
-        site_url="http://127.0.0.1/stable",
+        server_url="http://127.0.0.1",
+        site="stable",
         api_user="cmkadmin",
         api_secret="cmk",
         validate_certs=False,

--- a/tests/unit/plugins/inventory/test_option_resolution.py
+++ b/tests/unit/plugins/inventory/test_option_resolution.py
@@ -161,8 +161,8 @@ class TestIniResolution:
         monkeypatch.setenv("ANSIBLE_CONFIG", str(cfg))
 
         # Force Ansible to re-read its config so ANSIBLE_CONFIG takes effect.
-        from ansible.config.manager import ConfigManager
         import ansible.constants as C
+        from ansible.config.manager import ConfigManager
 
         monkeypatch.setattr(C, "config", ConfigManager())
 

--- a/tests/unit/plugins/module_utils/lookup_api.py
+++ b/tests/unit/plugins/module_utils/lookup_api.py
@@ -18,7 +18,8 @@ class CheckMKLookupAPI:
 
     def __init__(
         self,
-        site_url,
+        server_url,
+        site,
         api_auth_type="bearer",
         api_auth_cookie=None,
         api_user=None,
@@ -31,8 +32,8 @@ class CheckMKLookupAPI:
         }
         self.cookies = {}
 
-        self.site_url = site_url
-        self.url = "%s/check_mk/api/1.0" % site_url
+        self.site_url = "%s/%s" % (server_url.rstrip("/"), site)
+        self.url = "%s/check_mk/api/1.0" % self.site_url
         self.validate_certs = validate_certs
         # Bearer Authentication: "Bearer USERNAME PASSWORD"
         if api_auth_type == "bearer":

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+
+# Copyright: (c) 2026, Checkmk GmbH
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock
+
+import pytest
+from ansible_collections.checkmk.general.plugins.module_utils.api import CheckmkAPI
+
+
+def _api(server_url, site="mysite"):
+    module = MagicMock()
+    module.params = {
+        "server_url": server_url,
+        "site": site,
+        "api_auth_type": "bearer",
+        "api_user": "myuser",
+        "api_secret": "mysecret",
+    }
+    return CheckmkAPI(module)
+
+
+@pytest.mark.parametrize(
+    "server_url",
+    [
+        "http://myserver",
+        "http://myserver/",
+        "http://myserver//",
+    ],
+)
+def test_trailing_slash_is_normalized(server_url):
+    """A trailing slash must not produce a doubled slash before the site.
+
+    The collection documented the trailing-slash form for years, so both
+    have to build the same URL.
+    """
+    assert _api(server_url).url == "http://myserver/mysite/check_mk/api/1.0"
+
+
+def test_path_prefix_is_preserved():
+    """Only trailing slashes are stripped, not a path the user configured."""
+    assert (
+        _api("https://myserver/checkmk/").url
+        == "https://myserver/checkmk/mysite/check_mk/api/1.0"
+    )
+
+
+def test_missing_server_url_does_not_raise():
+    """server_url is required by the argument spec, but __init__ must not
+    blow up with a TypeError before Ansible reports that."""
+    assert _api(None).url == "/mysite/check_mk/api/1.0"

--- a/tests/unit/plugins/module_utils/test_lookup_api.py
+++ b/tests/unit/plugins/module_utils/test_lookup_api.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+
+# Copyright: (c) 2026, Checkmk GmbH
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from ansible_collections.checkmk.general.plugins.module_utils.lookup_api import (
+    CheckMKLookupAPI,
+)
+
+
+def _api(server_url, site="mysite"):
+    return CheckMKLookupAPI(
+        server_url=server_url,
+        site=site,
+        api_user="myuser",
+        api_secret="mysecret",
+    )
+
+
+@pytest.mark.parametrize(
+    "server_url",
+    [
+        "http://myserver",
+        "http://myserver/",
+        "http://myserver//",
+    ],
+)
+def test_trailing_slash_is_normalized(server_url):
+    """The collection documented the trailing-slash form for years, so both
+    have to build the same URL."""
+    assert _api(server_url).url == "http://myserver/mysite/check_mk/api/1.0"
+
+
+def test_path_prefix_is_preserved():
+    """Only trailing slashes are stripped, never a configured path prefix.
+
+    This is why the join is rstrip() and not urljoin(): urljoin treats the last
+    path segment as a document, so "https://myserver/checkmk" would lose the
+    prefix and resolve to "https://myserver/mysite".
+    """
+    assert (
+        _api("https://myserver/checkmk").url
+        == "https://myserver/checkmk/mysite/check_mk/api/1.0"
+    )
+
+
+def test_site_url_is_exposed_without_the_api_path():
+    assert _api("http://myserver/").site_url == "http://myserver/mysite"

--- a/tests/unit/plugins/modules/test_role.py
+++ b/tests/unit/plugins/modules/test_role.py
@@ -13,7 +13,6 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from ansible_collections.checkmk.general.plugins.module_utils.types import RESULT
 from ansible_collections.checkmk.general.plugins.modules.role import (
     BUILTIN_ROLES,


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- All modules, lookup plugins and the inventory plugin - Normalize a trailing
  slash on ``server_url``. The documentation consistently showed the
  ``https://myserver/`` form, which built request URLs with a doubled slash in
  front of the site name. The Checkmk REST API tolerates that, but other
  consumers of the same variable do not.

- Lookup plugins, Inventory plugin - ``CheckMKLookupAPI`` now takes
  ``server_url`` and ``site`` separately and joins them itself, instead of
  every caller building the site URL by hand. This only affects code importing
  the class directly from ``module_utils``, not playbooks or roles.


## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
