### PR TITLE
Accept a list of terms in the singular lookup plugins

### DIFF
--- a/changelogs/fragments/lookup_flatten_terms.yml
+++ b/changelogs/fragments/lookup_flatten_terms.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - Activation, Folder, Folders, Host, LDAP Connection, Role and Site lookup
+    modules - Terms can now be passed as a single list, not only as separate
+    arguments. Previously ``lookup('checkmk.general.host', my_host_list)``
+    failed with ``can only concatenate str (not "_AnsibleLazyTemplateList")``,
+    and the Activation lookup module silently built an invalid URL instead.

--- a/plugins/lookup/activation.py
+++ b/plugins/lookup/activation.py
@@ -18,8 +18,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: activation ID to look up
+        description:
+          - One or more activation IDs, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
     extends_documentation_fragment: [checkmk.general.common_lookup]
 
@@ -114,7 +117,7 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        for term in terms:
+        for term in self._flatten(terms):
             response = json.loads(api.get("/objects/activation_run/%s" % term))
 
             if "code" in response:

--- a/plugins/lookup/folder.py
+++ b/plugins/lookup/folder.py
@@ -18,8 +18,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: complete folder path using tilde as a delimiter
+        description:
+          - One or more complete folder paths using tilde as a delimiter, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
     extends_documentation_fragment: [checkmk.general.common_lookup]
 
@@ -132,7 +135,7 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        for term in terms:
+        for term in self._flatten(terms):
             response = json.loads(
                 api.get("/objects/folder_config/" + term.replace("/", "~"))
             )

--- a/plugins/lookup/folders.py
+++ b/plugins/lookup/folders.py
@@ -19,8 +19,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: complete folder path using tilde as a delimiter
+        description:
+          - One or more complete folder paths using tilde as a delimiter, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
       show_hosts:
         description: Also show the hosts of the folder(s) found
@@ -157,7 +160,7 @@ class LookupModule(LookupBase):
         )
 
         ret = []
-        for term in terms:
+        for term in self._flatten(terms):
             parameters = {
                 "parent": term.replace("/", "~"),
                 "recursive": recursive,

--- a/plugins/lookup/host.py
+++ b/plugins/lookup/host.py
@@ -18,8 +18,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: host name
+        description:
+          - One or more host names, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
       effective_attributes:
         description: show all effective attributes on hosts
@@ -142,7 +145,7 @@ class LookupModule(LookupBase):
             "effective_attributes": effective_attributes,
         }
 
-        for term in terms:
+        for term in self._flatten(terms):
             api_endpoint = "/objects/host_config/" + term
 
             response = json.loads(api.get("/objects/host_config/" + term, parameters))

--- a/plugins/lookup/ldap_connection.py
+++ b/plugins/lookup/ldap_connection.py
@@ -18,8 +18,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: ldap connection ID
+        description:
+          - One or more LDAP connection IDs, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
     extends_documentation_fragment: [checkmk.general.common_lookup]
 
@@ -118,7 +121,7 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        for term in terms:
+        for term in self._flatten(terms):
             response = json.loads(api.get("/objects/ldap_connection/" + term))
 
             if "code" in response:

--- a/plugins/lookup/role.py
+++ b/plugins/lookup/role.py
@@ -19,8 +19,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: role ID
+        description:
+          - One or more role IDs, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
     extends_documentation_fragment: [checkmk.general.common_lookup]
 
@@ -116,7 +119,7 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        for term in terms:
+        for term in self._flatten(terms):
             response = json.loads(api.get("/objects/user_role/" + term))
 
             if "code" in response:

--- a/plugins/lookup/site.py
+++ b/plugins/lookup/site.py
@@ -18,8 +18,11 @@ DOCUMENTATION = """
     options:
 
       _terms:
-        description: site ID
+        description:
+          - One or more site IDs, either as separate terms or as a single list.
         required: True
+        type: list
+        elements: str
 
     extends_documentation_fragment: [checkmk.general.common_lookup]
 
@@ -115,7 +118,7 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        for term in terms:
+        for term in self._flatten(terms):
             response = json.loads(api.get("/objects/site_connection/" + term))
 
             if "code" in response:

--- a/tests/integration/targets/lookup_host/tasks/test.yml
+++ b/tests/integration/targets/lookup_host/tasks/test.yml
@@ -58,6 +58,23 @@
               }}"
   loop: "{{ __checkmk_var_hosts_list }}"
 
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Get several hosts from a single list term."
+  ansible.builtin.set_fact:
+    __checkmk_var_flatten_list: "{{ lookup('checkmk.general.host',
+                                    checkmk_var_hosts | map(attribute='name') | list,
+                                    server_url=checkmk_var_server_url,
+                                    site=outer_item.site,
+                                    validate_certs=False,
+                                    api_user=checkmk_var_api_user,
+                                    api_secret=checkmk_var_api_secret,
+                                    wantlist=True) }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Verify one result per list entry."
+  ansible.builtin.assert:
+    that: "__checkmk_var_flatten_list | length == checkmk_var_hosts | map(attribute='name') | list | length"
+    fail_msg: "Expected {{ checkmk_var_hosts | map(attribute='name') | list | length }} results, but found {{ __checkmk_var_flatten_list | length }}!"
+    success_msg: "Expected {{ checkmk_var_hosts | map(attribute='name') | list | length }} results and found them."
+
 - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Use variables from inventory."
   block:
 

--- a/tests/integration/targets/lookup_role/tasks/test.yml
+++ b/tests/integration/targets/lookup_role/tasks/test.yml
@@ -115,6 +115,23 @@
     fail_msg: "Built-in admin role should expose a non-empty permissions list."
     success_msg: "Built-in admin role exposes {{ __checkmk_var_builtin_role.permissions | length }} permissions."
 
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Get several roles from a single list term."
+  ansible.builtin.set_fact:
+    __checkmk_var_flatten_list: "{{ lookup('checkmk.general.role',
+                                    checkmk_var_roles | map(attribute='name') | list,
+                                    server_url=checkmk_var_server_url,
+                                    site=outer_item.site,
+                                    validate_certs=False,
+                                    api_user=checkmk_var_api_user,
+                                    api_secret=checkmk_var_api_secret,
+                                    wantlist=True) }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Verify one result per list entry."
+  ansible.builtin.assert:
+    that: "__checkmk_var_flatten_list | length == checkmk_var_roles | map(attribute='name') | list | length"
+    fail_msg: "Expected {{ checkmk_var_roles | map(attribute='name') | list | length }} results, but found {{ __checkmk_var_flatten_list | length }}!"
+    success_msg: "Expected {{ checkmk_var_roles | map(attribute='name') | list | length }} results and found them."
+
 - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Use variables from inventory."
   block:
 


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Activation, Folder, Folders, Host, LDAP Connection, Role and Site lookup
  modules - Terms can now be passed as a single list, not only as separate
  arguments. Previously `lookup('checkmk.general.host', my_host_list)`
  failed with `can only concatenate str (not "_AnsibleLazyTemplateList")`,
  and the Activation lookup module silently built an invalid URL instead.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
