### PR TITLE
Include Checkmk's error detail in lookup API failures

### DIFF
--- a/changelogs/fragments/lookup_api_error_detail.yml
+++ b/changelogs/fragments/lookup_api_error_detail.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - All lookup modules - REST API errors now include the detail Checkmk reports
+    about them, instead of only the generic message belonging to the HTTP status
+    code. This makes validation failures diagnosable without inspecting the API
+    by hand.

--- a/plugins/module_utils/lookup_api.py
+++ b/plugins/module_utils/lookup_api.py
@@ -89,13 +89,34 @@ class CheckMKLookupAPI:
             )
             return to_text(raw_response.read())
         except HTTPError as e:
-            if e.code in HTTP_ERROR_CODES:
-                return json.dumps(
-                    {"code": e.code, "msg": HTTP_ERROR_CODES[e.code], "url": url}
-                )
-            else:
-                return json.dumps({"code": e.code, "msg": e.reason, "url": url})
+            msg = HTTP_ERROR_CODES.get(e.code, e.reason)
+            detail = self._error_detail(e)
+            if detail:
+                msg = "%s %s" % (msg, detail)
+            return json.dumps({"code": e.code, "msg": msg, "url": url})
         except URLError as e:
             return json.dumps({"code": 0, "msg": str(e), "url": url})
         except Exception as e:
             return json.dumps({"code": 0, "msg": str(e), "url": url})
+
+    @staticmethod
+    def _error_detail(error):
+        """Extract the human readable part of a Checkmk REST API error body.
+
+        The canned messages in HTTP_ERROR_CODES say what went wrong but not
+        which parameter caused it, which matters for endpoints that validate
+        a payload.
+        """
+        try:
+            body = json.loads(to_text(error.read()))
+        except Exception:
+            return ""
+
+        if not isinstance(body, dict):
+            return ""
+
+        parts = [body[key] for key in ("detail", "fields") if body.get(key)]
+
+        return " ".join(
+            part if isinstance(part, str) else json.dumps(part) for part in parts
+        )


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- All lookup modules - REST API errors now include the detail Checkmk reports
  about them, instead of only the generic message belonging to the HTTP status
  code. This makes validation failures diagnosable without inspecting the API
  by hand.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
