### PR TITLE
Add POST support and array query params to the lookup API

### DIFF
--- a/changelogs/fragments/lookup_api_post.yml
+++ b/changelogs/fragments/lookup_api_post.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - All lookup modules - Array query parameters are now sent as repeated keys,
+    e.g. ``columns=name&columns=state``, which is the form the REST API expects.
+  - All lookup modules - The lookup API can now issue ``POST`` requests. Checkmk
+    3.0.0 removes the ``GET`` variants of the monitoring collection endpoints,
+    which are ``POST`` only on every supported version.

--- a/plugins/module_utils/lookup_api.py
+++ b/plugins/module_utils/lookup_api.py
@@ -80,12 +80,27 @@ class CheckMKLookupAPI:
     def get(self, endpoint="", parameters=None):
         url = self.url + endpoint
 
-        try:
-            if parameters:
-                url = "%s?%s" % (url, urlencode(parameters))
+        if parameters:
+            # doseq renders list values as repeated keys (`columns=a&columns=b`),
+            # which is how the REST API expects array query parameters.
+            url = "%s?%s" % (url, urlencode(parameters, doseq=True))
 
+        return self._request(url)
+
+    def post(self, endpoint="", data=None):
+        url = self.url + endpoint
+        body = json.dumps(data if data is not None else {}).encode("utf-8")
+
+        return self._request(url, method="POST", data=body)
+
+    def _request(self, url, method="GET", data=None):
+        try:
             raw_response = open_url(
-                url, headers=self.headers, validate_certs=self.validate_certs
+                url,
+                method=method,
+                data=data,
+                headers=self.headers,
+                validate_certs=self.validate_certs,
             )
             return to_text(raw_response.read())
         except HTTPError as e:
@@ -105,7 +120,7 @@ class CheckMKLookupAPI:
 
         The canned messages in HTTP_ERROR_CODES say what went wrong but not
         which parameter caused it, which matters for endpoints that validate
-        a payload.
+        a payload, e.g. a Livestatus query expression.
         """
         try:
             body = json.loads(to_text(error.read()))


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- All lookup modules - Array query parameters are now sent as repeated keys,
  e.g. ``columns=name&columns=state``, which is the form the REST API expects.
- All lookup modules - The lookup API can now issue ``POST`` requests. Checkmk
  3.0.0 removes the ``GET`` variants of the monitoring collection endpoints,
  which are ``POST`` only on every supported version.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
