### PR TITLE
Add support for grouping hosts based on host labels

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -170,7 +170,7 @@ site: "mysite"
 api_user: "myuser"
 api_secret: "mysecret"
 # Group the hosts based on the following elements
-groupsources: ["hosttags", "sites"]
+groupsources: ["hosttags", "sites", "labels"]
 want_ipv4: false
 folder: "/"
 recursive: true
@@ -190,3 +190,32 @@ ansible-playbook -i checkmk.yml my_playbook.yml
 ```
 
 Ansible will now dynamically execute the playbook against the hosts monitored by your Checkmk site.
+
+### Host labels
+
+The labels of a host are always available as the host variable `checkmk_labels`,
+whether or not you list `labels` in `groupsources`.
+
+```yaml
+- name: "Show what Checkmk knows about a host."
+  hosts: all
+  tasks:
+    - name: "Print the labels."
+      ansible.builtin.debug:
+        var: checkmk_labels
+
+    - name: "Only run this on Linux hosts."
+      ansible.builtin.debug:
+        msg: "This is a Linux machine."
+      when: checkmk_labels['cmk/os_family'] | default('') == 'linux'
+```
+
+Adding `labels` to `groupsources` additionally creates one group per label, named
+`label_<key>_<value>`, so the example above can also be written as a host
+pattern:
+
+```bash
+ansible-playbook -i checkmk.yml my_playbook.yml --limit label_cmk_os_family_linux
+```
+
+Characters that are not valid in a group name are replaced by underscores.

--- a/changelogs/fragments/inventory_labels.yml
+++ b/changelogs/fragments/inventory_labels.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - Inventory plugin - Add C(labels) as a source for C(groupsources), which creates
+    one group per host label, named ``label_<key>_<value>``.
+    Characters that are not valid in a group name are replaced by underscores.
+  - Inventory plugin - The labels of a host are now available as the host variable
+    ``checkmk_labels``, whether or not ``labels`` is listed in ``groupsources``.
+    The effective labels are read from the monitoring core, so they include the
+    labels Checkmk assigns through label rules and service discovery and not only
+    the ones configured in Setup.

--- a/playbooks/inventory/checkmk.yml
+++ b/playbooks/inventory/checkmk.yml
@@ -4,7 +4,7 @@ site: "mysite"
 api_user: "myuser"
 api_secret: "mysecret"
 validate_certs: false
-groupsources: ["hosttags", "sites"]
+groupsources: ["hosttags", "sites", "labels"]
 want_ipv4: false
 folder: "/"
 recursive: true

--- a/plugins/inventory/checkmk.py
+++ b/plugins/inventory/checkmk.py
@@ -11,7 +11,8 @@ DOCUMENTATION = """
     short_description: Dynamic Inventory Source for Checkmk
     description:
         - Get hosts from any Checkmk site.
-        - Generate groups based on tag groups or sites in Checkmk.
+        - Generate groups based on tag groups, sites or labels in Checkmk.
+        - Sets the host labels as a dictionary variable C(checkmk_labels) for each host.
 
     extends_documentation_fragment: [checkmk.general.common_lookup]
 
@@ -24,7 +25,9 @@ DOCUMENTATION = """
         groupsources:
             description:
               - List of sources for grouping.
-              - Possible sources are C(sites) and C(hosttags).
+              - Possible sources are C(sites), C(hosttags) and C(labels).
+              - Grouping by C(labels) creates one group per label,
+                named C(label_<key>_<value>).
             type: list
             elements: str
             required: false
@@ -93,6 +96,17 @@ DOCUMENTATION = """
         - The C(lowercase_hosts) and C(domain_map) options change hostnames. If a
           transformation maps two different Checkmk hosts to the same name, they are
           merged into a single inventory host, so make sure transformed names stay unique.
+        - Labels are always fetched, whether or not C(labels) is listed in
+          C(groupsources), because C(checkmk_labels) is set for every host. This costs
+          one additional REST call per run, because the host configuration only knows
+          explicitly configured labels and the effective set has to be read from the
+          monitoring core. If that call fails, the run continues with the configured
+          labels and reports a warning.
+        - Only labels that at least one host actually has become groups. Unlike tag
+          groups, the set of labels is not known in advance.
+        - Group names replace every character that is neither a letter, a digit nor an
+          underscore with an underscore, so labels that differ only in such characters
+          share a group, e.g. C(my/label) and C(my_label).
 
     author:
         - Max Sickora (@max-checkmk)
@@ -105,18 +119,36 @@ EXAMPLES = """
 # one of the example blocks below and use it as your inventory source.
 # E.g., with `ansible-inventory -i checkmk.yml --graph`.
 
-# Group all hosts based on both tag groups and sites
+# Group all hosts based on tag groups, sites and labels
 # and update ansible_host with the ip address from Checkmk:
 plugin: checkmk.general.checkmk
 server_url: "http://myserver"
 site: "mysite"
 api_user: "myuser"
 api_secret: "mysecret"
-groupsources: ["hosttags", "sites"]
+groupsources: ["hosttags", "sites", "labels"]
 want_ipv4: true
 
 # The connection options are omitted in the following examples for brevity.
 # They can be set as shown above or via environment variables (see below).
+
+# ---------------------------------------------------------------------------
+# Using host labels
+# ---------------------------------------------------------------------------
+# The labels of a host are always exposed as the host variable
+# `checkmk_labels`, regardless of `groupsources`:
+#
+# - name: Show the labels of a host
+#   hosts: my_checkmk_host
+#   tasks:
+#     - name: Display the labels
+#       ansible.builtin.debug:
+#         var: checkmk_labels
+#
+#     - name: Run a task only if a label is set
+#       ansible.builtin.debug:
+#         msg: "This is a Linux machine."
+#       when: checkmk_labels['cmk/os_family'] | default('') == 'linux'
 
 # Exclude test and offline systems from the inventory:
 plugin: checkmk.general.checkmk
@@ -334,6 +366,9 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.add_host(host["id"])
             self.inventory.set_variable(host["id"], "ipaddress", host["ipaddress"])
             self.inventory.set_variable(host["id"], "folder", host["folder"])
+            self.inventory.set_variable(
+                host["id"], "checkmk_labels", host.get("labels", {})
+            )
             if self.want_ipv4:
                 self.inventory.set_variable(
                     host["id"], "ansible_host", host["ipaddress"]
@@ -355,6 +390,17 @@ class InventoryModule(BaseInventoryPlugin):
                     self.inventory.add_child(
                         "site_" + self.convertname(host.get("site")), host.get("id")
                     )
+            if "labels" in self.groupsources:
+                # Unlike tag groups and sites, the set of labels is not known
+                # before the hosts have been fetched, so the groups cannot be
+                # pre-created in _generate_groups() and are added here.
+                for host in self.hosts:
+                    for key, value in host.get("labels", {}).items():
+                        group_name = self.convertname(
+                            "label_{0}_{1}".format(key, value)
+                        )
+                        self.inventory.add_group(group_name)
+                        self.inventory.add_child(group_name, host.get("id"))
 
     def _get_domain_suffix(self, host_tags):
         """Return the suffix of the first domain_map entry matching a host tag, or empty string."""
@@ -389,9 +435,17 @@ class InventoryModule(BaseInventoryPlugin):
             )
         return False
 
-    def _parse_hosts(self, raw_hosts):
-        """Convert raw API host list to internal format, apply folder, exclude_tags and domain_map."""
+    def _parse_hosts(self, raw_hosts, livestatus_labels=None):
+        """Convert raw API host list to internal format, apply folder, exclude_tags and domain_map.
+
+        ``livestatus_labels`` maps the Checkmk host name to the labels the
+        monitoring core actually uses. It is merged on top of the labels from
+        the host configuration, which do not include labels added by rules or
+        discovery. The merge happens before the hostname transformations, so it
+        is always keyed by the original Checkmk host name.
+        """
         folder_target = normalize_folder(self.folder) if self.folder else None
+        livestatus_labels = livestatus_labels or {}
         hosts = []
         for host in raw_hosts:
             host_id = host.get("id")
@@ -402,12 +456,17 @@ class InventoryModule(BaseInventoryPlugin):
                 .items()
                 if taggroup in self.tags
             }
+            host_labels = dict(
+                host.get("extensions").get("effective_attributes").get("labels") or {}
+            )
+            host_labels.update(livestatus_labels.get(host_id) or {})
             parsed = {
                 "id": host_id,
                 "title": host.get("extensions").get("title"),
                 "ipaddress": host.get("extensions").get("attributes").get("ipaddress"),
                 "folder": host.get("extensions").get("folder"),
                 "site": host.get("extensions").get("effective_attributes").get("site"),
+                "labels": host_labels,
                 "tags": host_tags,
             }
 
@@ -458,7 +517,52 @@ class InventoryModule(BaseInventoryPlugin):
                 )
             )
 
-        return self._parse_hosts(response.get("value", []))
+        return self._parse_hosts(
+            response.get("value", []), self._get_livestatus_labels(api)
+        )
+
+    def _get_livestatus_labels(self, api):
+        """Return the labels the monitoring core uses, keyed by host name.
+
+        The host configuration only knows explicitly configured labels, so the
+        monitoring core is queried for the effective set, which also covers
+        labels from rules and discovery. A failure here is not fatal: the
+        configuration labels are used as a fallback.
+        """
+        try:
+            # POST and not GET: the GET variant of this endpoint is deprecated
+            # since Checkmk 2.3 and no longer available in 3.0, while POST is
+            # supported on all versions this collection supports.
+            response = json.loads(
+                api.post(
+                    "/domain-types/host/collections/all",
+                    {"columns": ["name", "labels"]},
+                )
+            )
+        except Exception as e:
+            display.warning(
+                "Could not fetch the labels from the monitoring core: %s. "
+                "Falling back to the labels from the host configuration." % e
+            )
+            return {}
+
+        if "code" in response:
+            display.warning(
+                "Could not fetch the labels from the monitoring core: %s - %s. "
+                "Falling back to the labels from the host configuration."
+                % (response.get("code", ""), response.get("msg", ""))
+            )
+            return {}
+
+        labels = {}
+        for host in response.get("value", []):
+            extensions = host.get("extensions") or {}
+            # The host name is the object identifier; it is additionally
+            # returned as the "name" column that is requested above.
+            host_name = extensions.get("name") or host.get("id")
+            if host_name:
+                labels[host_name] = extensions.get("labels") or {}
+        return labels
 
     def _get_taggroups(self, api):
         response = json.loads(api.get("/domain-types/host_tag_group/collections/all"))

--- a/tests/integration/targets/inventory_checkmk/tasks/test.yml
+++ b/tests/integration/targets/inventory_checkmk/tasks/test.yml
@@ -22,6 +22,7 @@
       site: "{{ outer_item.site }}"
       tag_criticality: "{{ item.criticality }}"
       ipaddress: "{{ item.ipaddress | default(omit) }}"
+      labels: "{{ item.labels | default(omit) }}"
     state: "present"
   loop: "{{ checkmk_var_hosts }}"
 
@@ -72,6 +73,8 @@
       - "checkmk_var_hosts | map(attribute='name') | difference(__checkmk_var_inventory['site_' ~ outer_item.site]['hosts']) | length == 0"
       - "__checkmk_var_inventory._meta.hostvars['inv-prod'].ansible_host == '127.0.0.1'"
       - "__checkmk_var_inventory._meta.hostvars['inv-sub'].folder == '/top/sub'"
+      - "__checkmk_var_inventory._meta.hostvars['inv-prod'].checkmk_labels['os_family'] == 'linux'"
+      - "'label_os_family_linux' not in __checkmk_var_inventory"
 
 - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Scenario 'folder': Run inventory."
   ansible.builtin.include_tasks: run_inventory.yml
@@ -166,6 +169,27 @@
       - "__checkmk_var_inventory_hosts == ['inv-prod.example.com', 'inv-upper.example.com']"
       - "'inv-prod.example.com' in __checkmk_var_inventory['tag_criticality_prod']['hosts']"
       - "__checkmk_var_inventory._meta.hostvars['inv-prod.example.com'].ansible_host == '127.0.0.1'"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Scenario 'labels': Run inventory."
+  ansible.builtin.include_tasks: run_inventory.yml
+  vars:
+    __checkmk_var_scenario: "labels"
+    __checkmk_var_inventory_options:
+      groupsources: ["labels"]
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Scenario 'labels': Verify label groups and host variables."
+  ansible.builtin.assert:
+    that:
+      - "'inv-prod' in __checkmk_var_inventory['label_os_family_linux']['hosts']"
+      - "'inv-sub' in __checkmk_var_inventory['label_os_family_windows']['hosts']"
+      # The space of "ops team" has to be gone from the group name.
+      - "'inv-prod' in __checkmk_var_inventory['label_team_opsteam']['hosts']"
+      - "'inv-sub' not in __checkmk_var_inventory['label_os_family_linux']['hosts']"
+      # A host without labels is inventoried, just not grouped by one.
+      - "'inv-offline' in __checkmk_var_inventory_hosts"
+      - "'os_family' not in __checkmk_var_inventory._meta.hostvars['inv-offline'].checkmk_labels"
+      # No group exists for a label value nobody uses.
+      - "'label_os_family_solaris' not in __checkmk_var_inventory"
 
 - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Scenario 'environment': Run inventory."
   ansible.builtin.include_tasks: run_inventory.yml

--- a/tests/integration/targets/inventory_checkmk/vars/main.yml
+++ b/tests/integration/targets/inventory_checkmk/vars/main.yml
@@ -19,9 +19,15 @@ checkmk_var_hosts:
     folder: "/top"
     criticality: "prod"
     ipaddress: "127.0.0.1"
+    # The space is intentional: it has to be sanitized out of the group name.
+    labels:
+      os_family: "linux"
+      team: "ops team"
   - name: inv-sub
     folder: "/top/sub"
     criticality: "test"
+    labels:
+      os_family: "windows"
   - name: INV-UPPER
     folder: "/other"
     criticality: "prod"

--- a/tests/unit/plugins/inventory/test_labels.py
+++ b/tests/unit/plugins/inventory/test_labels.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+
+# Copyright: (c) 2026, Checkmk GmbH
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Host labels in the inventory plugin.
+
+Labels come from two places and neither alone is enough. The host
+configuration knows only the labels somebody typed into Setup, while the
+labels that actually apply -- the ones from label rules and from discovery --
+are only known to the monitoring core. The plugin therefore reads both and
+merges the core's view on top.
+
+Three things about that are easy to get wrong and are pinned here:
+
+* the merge is keyed by the Checkmk host name, which is not necessarily the
+  inventory hostname, because ``domain_map`` and ``lowercase_hosts`` rewrite it,
+* the host name in the monitoring response is the object id and the ``name``
+  column, never a top-level ``name`` key,
+* and the core is queried with POST, because the GET variant of that endpoint is
+  deprecated and Checkmk 3.0 no longer serves it.
+
+A failure to reach the core is not fatal: an inventory that lists every host
+with the configured labels is far more useful than no inventory at all.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+import pytest
+from ansible_collections.checkmk.general.plugins.inventory.checkmk import (
+    InventoryModule,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HOST_COLLECTION_ENDPOINT = "/domain-types/host/collections/all"
+
+
+class FakeAPI:
+    """Records the calls and answers the monitoring query from a canned body."""
+
+    def __init__(self, monitoring_response=None, monitoring_exception=None):
+        self.monitoring_response = monitoring_response
+        self.monitoring_exception = monitoring_exception
+        self.calls = []
+
+    def get(self, endpoint, parameters=None):
+        self.calls.append(("GET", endpoint, parameters))
+        raise AssertionError("the monitoring core must not be queried with GET")
+
+    def post(self, endpoint, data=None):
+        self.calls.append(("POST", endpoint, data))
+        if self.monitoring_exception:
+            raise self.monitoring_exception
+        return json.dumps(self.monitoring_response)
+
+
+def _raw_host(host_id, labels, tag="prod"):
+    """A host as the host_config collection returns it."""
+    return {
+        "id": host_id,
+        "extensions": {
+            "title": host_id,
+            "folder": "/",
+            "attributes": {"ipaddress": "127.0.0.1"},
+            "effective_attributes": {
+                "site": "mysite",
+                "labels": labels,
+                "tag_criticality": tag,
+            },
+        },
+    }
+
+
+def _monitored_host(host_id, labels, with_name_column=True):
+    """A host as the monitoring collection returns it.
+
+    The requested livestatus columns land in ``extensions``; ``id`` and
+    ``title`` carry the host name.
+    """
+    extensions = {"labels": labels}
+    if with_name_column:
+        extensions["name"] = host_id
+    return {"id": host_id, "title": host_id, "extensions": extensions}
+
+
+class FakeInventory:
+    def __init__(self):
+        self.groups = []
+        self.children = []
+        self.variables = {}
+
+    def add_group(self, group):
+        self.groups.append(group)
+
+    def add_host(self, host):
+        pass
+
+    def add_child(self, group, host):
+        self.children.append((group, host))
+
+    def set_variable(self, host, key, value):
+        self.variables.setdefault(host, {})[key] = value
+
+
+@pytest.fixture
+def plugin():
+    module = InventoryModule()
+    module.inventory = FakeInventory()
+    module.tags = ["tag_criticality"]
+    module.groupsources = []
+    module.want_ipv4 = False
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Reading the effective labels from the monitoring core
+# ---------------------------------------------------------------------------
+
+
+def test_the_core_is_queried_with_post_for_name_and_labels(plugin):
+    """GET on this endpoint is deprecated and gone in Checkmk 3.0, and the two
+    columns have to be separate list entries, or livestatus sees one column
+    called "name,labels" and rejects the query."""
+    api = FakeAPI({"value": [_monitored_host("myhost", {"cmk/os_family": "linux"})]})
+
+    labels = plugin._get_livestatus_labels(api)
+
+    assert api.calls == [
+        ("POST", HOST_COLLECTION_ENDPOINT, {"columns": ["name", "labels"]})
+    ]
+    assert labels == {"myhost": {"cmk/os_family": "linux"}}
+
+
+def test_labels_are_keyed_by_the_host_name_not_a_top_level_field(plugin):
+    """There is no top-level ``name`` in the response. Reading one yields None
+    for every host, which silently turns the whole merge into a no-op."""
+    api = FakeAPI(
+        {
+            "value": [
+                _monitored_host("with-column", {"a": "1"}),
+                _monitored_host("without-column", {"b": "2"}, with_name_column=False),
+            ]
+        }
+    )
+
+    assert plugin._get_livestatus_labels(api) == {
+        "with-column": {"a": "1"},
+        "without-column": {"b": "2"},
+    }
+
+
+def test_a_host_without_labels_is_kept_as_an_empty_mapping(plugin):
+    api = FakeAPI({"value": [_monitored_host("myhost", None)]})
+
+    assert plugin._get_livestatus_labels(api) == {"myhost": {}}
+
+
+@pytest.mark.parametrize(
+    "api",
+    [
+        # The lookup API reports HTTP errors as a body, it does not raise.
+        FakeAPI({"code": 403, "msg": "Forbidden", "url": "http://myserver"}),
+        FakeAPI(monitoring_exception=ValueError("no JSON at all")),
+    ],
+    ids=["api_error_body", "unparseable_response"],
+)
+def test_an_unreachable_core_is_not_fatal(plugin, api):
+    """Losing the rule and discovery labels is worth a warning, not a failed
+    inventory: the configured labels are still there."""
+    assert plugin._get_livestatus_labels(api) == {}
+
+
+# ---------------------------------------------------------------------------
+# Merging them into the hosts
+# ---------------------------------------------------------------------------
+
+
+def test_the_core_wins_and_configured_labels_survive(plugin):
+    raw = [_raw_host("myhost", {"cmk/os_family": "windows", "configured": "yes"})]
+
+    hosts = plugin._parse_hosts(raw, {"myhost": {"cmk/os_family": "linux"}})
+
+    assert hosts[0]["labels"] == {
+        "cmk/os_family": "linux",
+        "configured": "yes",
+    }
+
+
+def test_the_api_response_is_not_mutated(plugin):
+    """The parsed hosts must not alias the response, or a second pass over the
+    same payload would see labels that were merged in during the first."""
+    raw = [_raw_host("myhost", {"configured": "yes"})]
+
+    plugin._parse_hosts(raw, {"myhost": {"from_the_core": "yes"}})
+
+    assert raw[0]["extensions"]["effective_attributes"]["labels"] == {
+        "configured": "yes"
+    }
+
+
+def test_hosts_without_labels_get_an_empty_mapping(plugin):
+    """``labels`` can be absent entirely or present as null."""
+    raw = [_raw_host("no-key", {}), _raw_host("null-value", None)]
+    del raw[0]["extensions"]["effective_attributes"]["labels"]
+
+    hosts = plugin._parse_hosts(raw, {})
+
+    assert [host["labels"] for host in hosts] == [{}, {}]
+
+
+def test_labels_are_merged_before_the_hostname_is_rewritten(plugin):
+    """The core knows the Checkmk host name. ``domain_map`` and
+    ``lowercase_hosts`` rename hosts, so merging after the rename would look up
+    a name the core never reported."""
+    plugin.lowercase_hosts = True
+    plugin.domain_map = {"tag_criticality_prod": ".example.com"}
+    raw = [_raw_host("MYHOST", {"configured": "yes"})]
+
+    hosts = plugin._parse_hosts(raw, {"MYHOST": {"from_the_core": "yes"}})
+
+    assert hosts[0]["id"] == "myhost.example.com"
+    assert hosts[0]["labels"] == {"configured": "yes", "from_the_core": "yes"}
+
+
+# ---------------------------------------------------------------------------
+# Exposing them as variables and groups
+# ---------------------------------------------------------------------------
+
+
+def test_labels_are_exposed_even_without_grouping(plugin):
+    """``checkmk_labels`` is the reason the labels are always fetched; it does
+    not depend on `labels` being a groupsource."""
+    plugin.hosts = [
+        {
+            "id": "myhost",
+            "ipaddress": "127.0.0.1",
+            "folder": "/",
+            "site": "mysite",
+            "tags": {},
+            "labels": {"cmk/os_family": "linux"},
+        }
+    ]
+
+    plugin._populate()
+
+    assert plugin.inventory.variables["myhost"]["checkmk_labels"] == {
+        "cmk/os_family": "linux"
+    }
+    assert plugin.inventory.groups == []
+
+
+def test_a_group_is_created_per_label(plugin):
+    """Label groups cannot be pre-created in _generate_groups(), because the
+    labels are only known once the hosts have been read."""
+    plugin.groupsources = ["labels"]
+    plugin.hosts = [
+        {
+            "id": "linux-host",
+            "ipaddress": "127.0.0.1",
+            "folder": "/",
+            "site": "mysite",
+            "tags": {},
+            "labels": {"cmk/os_family": "linux", "team": "ops team"},
+        },
+        {
+            "id": "unlabelled-host",
+            "ipaddress": "127.0.0.2",
+            "folder": "/",
+            "site": "mysite",
+            "tags": {},
+            "labels": {},
+        },
+    ]
+
+    plugin._populate()
+
+    # Slashes and spaces are not valid in group names.
+    assert sorted(plugin.inventory.groups) == [
+        "label_cmk_os_family_linux",
+        "label_team_opsteam",
+    ]
+    assert sorted(plugin.inventory.children) == [
+        ("label_cmk_os_family_linux", "linux-host"),
+        ("label_team_opsteam", "linux-host"),
+    ]
+    assert plugin.inventory.variables["unlabelled-host"]["checkmk_labels"] == {}


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Host labels can neither be read as a variable, nor be used as a group source.

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Add `labels` as a source for `groupsources` which creates one group per host label, named `label_<key>_<value>`. Characters that are not valid in a group name are replaced by underscores.
- The labels of a host are now available as the host variable `checkmk_labels`, whether or not `labels` is listed in `groupsources``.  The effective labels are read from the monitoring core, so they include the labels Checkmk assigns through label rules and service discovery and not only the ones configured in Setup.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
