### PR TITLE
Fix site connections without configuration replication for Checkmk 2.5.

### DIFF
--- a/changelogs/fragments/site.yml
+++ b/changelogs/fragments/site.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - Site module - Fix site connections without configuration replication being
+    impossible to create on Checkmk 2.5.0 and newer, where the API requires the
+    fields that Werk 16722 had made optional.
+  - Site module - Fail with an actionable message when ``message_broker_port``
+    is missing while creating a connection on Checkmk 2.5.0 and newer, where
+    the API requires it.

--- a/plugins/doc_fragments/site_options.py
+++ b/plugins/doc_fragments/site_options.py
@@ -321,6 +321,14 @@ class ModuleDocFragment(object):
                                 message_broker_port:
                                     description:
                                         - The port used by the message broker to exchange messages.
+                                        - Available from Checkmk 2.4.0 on, and B(required) from
+                                          2.5.0 on for every connection, whether replication is
+                                          enabled or not.
+                                        - There is no safe default. OMD assigns C(RABBITMQ_PORT)
+                                          when a site is created, so the second site on a machine
+                                          gets 5673 and the third 5674. Read the value from the
+                                          machine hosting the remote site with
+                                          C(omd config <site> show RABBITMQ_PORT).
                                     type: int
                         basic_settings:
                             description:

--- a/plugins/modules/site.py
+++ b/plugins/modules/site.py
@@ -67,6 +67,36 @@ EXAMPLES = r"""
           alias: "My Remote Site"
     state: "present"
 
+- name: "Add a read-only remote site, without configuration replication."
+  checkmk.general.site:
+    server_url: "https://myserver"
+    site: "mysite"
+    api_user: "myuser"
+    api_secret: "mysecret"
+    site_id: "customersite"
+    site_connection:
+      site_config:
+        status_connection:
+          connection:
+            socket_type: "tcp"
+            port: 6557
+            encrypted: true
+            host: "customersite.example.com"
+            verify: true
+          proxy:
+            use_livestatus_daemon: "direct"
+          connect_timeout: 2
+          status_host:
+            status_host_set: "disabled"
+          url_prefix: "/customersite/"
+        configuration_connection:
+          enable_replication: false
+          message_broker_port: 5672
+        basic_settings:
+          site_id: "customersite"
+          alias: "Customer Site"
+    state: "present"
+
 - name: "Delete a remote site connection."
   checkmk.general.site:
     server_url: "https://myserver"
@@ -304,6 +334,57 @@ class SiteAPI(CheckmkAPI):
                 logger=logger,
             )
 
+    def verify_message_broker_port(self):
+        """Only called when a connection is about to be created.
+
+        From 2.5.0 on, the API requires message_broker_port on every
+        connection, replicated or not. There is no safe default: OMD assigns
+        RABBITMQ_PORT per site, so the second site on a machine gets 5673 and
+        the third 5674. Defaulting to 5672 would create connections that look
+        fine and point the broker at the wrong site, so fail loudly instead.
+
+        An update does not need the parameter, because merge_with() takes the
+        stored value from the existing connection.
+        """
+        message_broker_port = (
+            self.params.get("site_connection", {})
+            .get("site_config", {})
+            .get("configuration_connection", {})
+            .get("message_broker_port")
+        )
+
+        if self.getversion() >= CheckmkVersion("2.5.0") and not message_broker_port:
+            exit_module(
+                self.module,
+                msg=(
+                    "The parameter message_broker_port is required when creating a "
+                    "connection on Checkmk versions starting with 2.5.0. Read it "
+                    "from the machine hosting the remote site with "
+                    "'omd config <site> show RABBITMQ_PORT'. "
+                    "Version found: %s" % self.getversion()
+                ),
+                failed=True,
+                logger=logger,
+            )
+
+
+def strips_unreplicated_fields(version):
+    """Whether the API accepts a configuration_connection that carries nothing
+    but enable_replication.
+
+    Werk 16722 made the other fields optional for connections without
+    replication, and 2.4 models that as a dedicated schema
+    (ConfigurationConnectionWithoutReplicationAttributes, which requires only
+    enable_replication).
+
+    2.5 collapsed the two schemas into a single ConnectionModel that requires
+    all of them again, whether replication is enabled or not, and 3.0 behaves
+    the same way. So the stripping applies to the 2.4 span only, and sending a
+    bare {"enable_replication": false} to 2.5 gets a 400 listing eight missing
+    required fields.
+    """
+    return CheckmkVersion("2.3.0p25") < version < CheckmkVersion("2.5.0")
+
 
 def werk16722(site_config):
     # Remove previously mandatory fields. See https://checkmk.com/werk/16722
@@ -349,8 +430,8 @@ def run_module():
         .get("enable_replication", False)
     )
 
-    # Can be removed, once we no longer support Checkmk versions older than 2.3.0p25
-    if site_api.getversion() > CheckmkVersion("2.3.0p25") and not replication_enabled:
+    # Can be removed, once we no longer support Checkmk 2.4
+    if strips_unreplicated_fields(site_api.getversion()) and not replication_enabled:
         # Remove unneeded parameters from the module's parameters
         logger.debug("Cleaning up module parameters")
         werk16722(module.params.get("site_connection", {}).get("site_config", {}))
@@ -358,10 +439,10 @@ def run_module():
     desired_site_connection = SiteConnection.from_module_params(module.params)
     existing_site_connection = SiteConnection.from_api(site_api.get(site_id))
 
-    # Can be removed, once we no longer support Checkmk versions older than 2.3.0p25
+    # Can be removed, once we no longer support Checkmk 2.4
     if (
         existing_site_connection
-        and site_api.getversion() > CheckmkVersion("2.3.0p25")
+        and strips_unreplicated_fields(site_api.getversion())
         and not replication_enabled
     ):
         # Remove unneeded parameters from the existing site connection's config
@@ -390,6 +471,7 @@ def run_module():
                 )
 
         else:
+            site_api.verify_message_broker_port()
             result = site_api.create(desired_site_connection)
 
         exit_module(module, result=result, logger=logger)

--- a/tests/integration/targets/site/tasks/test.yml
+++ b/tests/integration/targets/site/tasks/test.yml
@@ -62,7 +62,6 @@
   failed_when: __checkmk_var_result_login.changed | bool
 
 - name: "{{ outer_item.version }}.{{ outer_item.edition }} - Update site connection."
-  when: "(outer_item.version | regex_replace('p.*', '')) is version('2.5.0', '!=')"
   site:
     server_url: "{{ checkmk_var_server_url }}"
     site: "{{ outer_item.site }}"
@@ -73,8 +72,8 @@
       site_config:
         basic_settings:
           alias: "{{ item.site_id }} with new alias"
-        configuration_connection:
-        status_connection:
+        configuration_connection: "{{ item.site_config.configuration_connection }}"
+        status_connection: "{{ item.site_config.status_connection }}"
     state: "present"
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
@@ -91,6 +90,8 @@
       site_config:
         basic_settings:
           alias: "{{ item.site_id }} with new alias"
+        configuration_connection: "{{ item.site_config.configuration_connection }}"
+        status_connection: "{{ item.site_config.status_connection }}"
     state: "present"
   loop: "{{ outer_item.remote_sites }}"
   loop_control:
@@ -160,3 +161,46 @@
   environment: "{{ __checkmk_var_testing_environment }}"
   register: __checkmk_var_result_environment
   failed_when: __checkmk_var_result_environment.changed | bool
+
+# A connection without configuration replication.
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create status-only site connection."
+  site:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    site_id: "{{ item.site_id }}"
+    site_connection:
+      site_config: "{{ item.site_config }}"
+    state: "present"
+  loop: "{{ outer_item.status_only_sites }}"
+  loop_control:
+    label: "{{ item.site_id }}"
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Create status-only site connection again."
+  site:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    site_id: "{{ item.site_id }}"
+    site_connection:
+      site_config: "{{ item.site_config }}"
+    state: "present"
+  loop: "{{ outer_item.status_only_sites }}"
+  loop_control:
+    label: "{{ item.site_id }}"
+  register: __checkmk_var_result_status_only
+  failed_when: __checkmk_var_result_status_only.changed | bool
+
+- name: "{{ outer_item.version }}.{{ outer_item.edition }} - Delete status-only site connection."
+  site:
+    server_url: "{{ checkmk_var_server_url }}"
+    site: "{{ outer_item.site }}"
+    api_user: "{{ checkmk_var_api_user }}"
+    api_secret: "{{ checkmk_var_api_secret }}"
+    site_id: "{{ item.site_id }}"
+    state: "absent"
+  loop: "{{ outer_item.status_only_sites }}"
+  loop_control:
+    label: "{{ item.site_id }}"

--- a/tests/integration/targets/site/vars/main.yml
+++ b/tests/integration/targets/site/vars/main.yml
@@ -49,3 +49,30 @@ checkmk_var_test_sites:
         authentication:
           username: "{{ checkmk_var_api_user }}"
           password: "{{ checkmk_var_api_secret }}"
+    # Connections without configuration replication.
+    # They cannot log in, so they sit beside remote_sites rather than in it,
+    # and setup_checkmk creates no site for them.
+    status_only_sites:
+      - site_id: "testsite_s_1"
+        site_config:
+          status_connection:
+            connection:
+              socket_type: "tcp"
+              port: 6557
+              encrypted: true
+              host: "localhost"
+              verify: false
+            proxy:
+              use_livestatus_daemon: "direct"
+            connect_timeout: 2
+            status_host:
+              status_host_set: "disabled"
+            url_prefix: "/testsite_s_1/"
+            disable_in_status_gui: false
+          configuration_connection:
+            enable_replication: false
+            message_broker_port: "{{ (checkmk_var_version | regex_replace('p.*', '') is version('2.4', '>=')) | ternary(5671, omit) }}"
+          basic_settings:
+            site_id: "testsite_s_1"
+            alias: "status only test site 1"
+            customer: "{{ (checkmk_var_edition in ['managed', 'ultimatemt']) | ternary('provider', None) }}"


### PR DESCRIPTION
## Pull request type
> Try to limit your pull request to one type, submit multiple pull requests if needed.

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (describe what kind of change you performed):

## What is the current behavior?
> Describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #1179 

## What is the new behavior?
> Describe the behavior or changes that are being added by this PR.

- Fix site connections without configuration replication being impossible to create on Checkmk 2.5.0 and newer, where the API requires the fields that Werk 16722 had made optional.
- Fail with an actionable message when ``message_broker_port`` is missing while creating a connection on Checkmk 2.5.0 and newer, where the API requires it.

## Other information
> Any other information that is important to this PR, e.g screenshots of how the component looks before and after the change.
